### PR TITLE
Jira bridge users can adopt an identity in credential metadata

### DIFF
--- a/bridge/core/auth/credential.go
+++ b/bridge/core/auth/credential.go
@@ -21,8 +21,9 @@ const (
 	configKeySalt       = "salt"
 	configKeyPrefixMeta = "meta."
 
-	MetaKeyLogin   = "login"
-	MetaKeyBaseURL = "base-url"
+	MetaKeyLogin    = "login"
+	MetaKeyBaseURL  = "base-url"
+	MetaKeyIdentity = "identity"
 )
 
 type CredentialKind string


### PR DESCRIPTION
It sounds like @MichaelMure has a plan for the "correct" thing to do. But this was easy and it got me unblocked. It allows an `identity` to be specified in the metadata of a credential (e.g. in the git config). 

Fixes: #351 
