### PR TITLE
feat: add check for allowed OSS licenses

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,3 +56,6 @@ jobs:
 
       - name: Check Security (vulnerable dependencies and insecure practices)
         run: make secure
+
+      - name: Check that all included packages have acceptable OSS licenses
+        run: make lint

--- a/.lichen.yaml
+++ b/.lichen.yaml
@@ -1,0 +1,21 @@
+---
+# Configuration for the Lichen software license scanner.  The list below
+# represents the licenses that are currently compiled into the git-bug
+# binary (with the exception of the GPL license which is git-bug's own
+# license and is therefore compatible.)  Licenses can be added to the
+# "allow" list using the official identifiers from the SPDX License
+# List which can be found at https://spdx.org/licenses/.
+#
+# The Lichen configuration file format allows overrides (for packages
+# where the license can't be automatically discovered) and exceptions
+# (to allow disallowed licenses for certain packages).  The format for
+# this file can be found at https://github.com/uw-labs/lichen#config.
+
+allow:
+- "Apache-2.0"
+- "BSD-2-Clause"
+- "BSD-3-Clause"
+- "GPL-3.0-or-later"
+- "ISC"
+- "MIT"
+- "MPL-2.0"

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ secure-vulnerabilities:
 	go install golang.org/x/vuln/cmd/govulncheck@latest
 	govulncheck ./... 
 
+legal: build
+	go install github.com/uw-labs/lichen@latest
+	lichen --config=.lichen.yaml ./git-bug
+
 test:
 	go test -v -bench=. ./...
 


### PR DESCRIPTION
This addition to the `Makefile` and Github workflow breaks the build if a package is added that doesn't have an approved OSS license.  The (current) approved list can be found in `.lichen.yaml` which was populated from the list of licenses of packages that are already included in the library.

The license checks can also be run locally using `make legal`.