### PR TITLE
feat(ci): support a merge queue

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -9,6 +9,9 @@
 name: presubmit
 
 on:
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     branches:
       - master


### PR DESCRIPTION
```
feat(ci): support a merge queue

This change adds support for using the [Merge Queue][0] merge method.
This still needs to be enforced at the repository level.

[0]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

Change-Id: I4b464818c0cd82d1d56c4dd7f807f6cfc5dfa913
```

