### PR TITLE
feat: add package to dev shell: delve

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
         devShell = pkgs.mkShell {
           packages = with pkgs; [
             codespell
+            delve
             gh
             git
             go


### PR DESCRIPTION
This change adds `delve`, the de facto debugger for go, to the
development shell..

Change-Id: I0bcda2b3569926dc16d8cbd653845f371ef33452