### PR TITLE
feat: update references to the git-bug organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ show a command that [clones the repository][how-to-clone] using SSH, and places
 it in `~/code/git-bug`.
 
 ```
-git clone git@github.com:MichaelMure/git-bug ~/code/git-bug
+git clone git@github.com:git-bug/git-bug ~/code/git-bug
 ```
 
 > [!IMPORTANT]

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ifeq ($(UNAME_S),Darwin)
     XARGS:=xargs
 endif
 
-COMMANDS_PATH:=github.com/MichaelMure/git-bug/commands
+COMMANDS_PATH:=github.com/git-bug/git-bug/commands
 LDFLAGS:=-X ${COMMANDS_PATH}.GitCommit=${GIT_COMMIT} \
 	-X ${COMMANDS_PATH}.GitLastTag=${GIT_LAST_TAG} \
 	-X ${COMMANDS_PATH}.GitExactTag=${GIT_EXACT_TAG}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img width="150px" src="https://cdn.rawgit.com/MichaelMure/git-bug/master/misc/logo/logo-alpha-flat-bg.svg">
+    <img width="150px" src="https://cdn.rawgit.com/git-bug/git-bug/master/misc/logo/logo-alpha-flat-bg.svg">
 </p>
 <h1 align="center">git-bug</h1>
 
@@ -8,8 +8,8 @@
 [![Backers on Open Collective](https://opencollective.com/git-bug/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/git-bug/sponsors/badge.svg)](#sponsors)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3+-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
-[![GoDoc](https://godoc.org/github.com/MichaelMure/git-bug?status.svg)](https://godoc.org/github.com/MichaelMure/git-bug)
-[![Go Report Card](https://goreportcard.com/badge/github.com/MichaelMure/git-bug)](https://goreportcard.com/report/github.com/MichaelMure/git-bug)
+[![GoDoc](https://godoc.org/github.com/git-bug/git-bug?status.svg)](https://godoc.org/github.com/git-bug/git-bug)
+[![Go Report Card](https://goreportcard.com/badge/github.com/git-bug/git-bug)](https://goreportcard.com/report/github.com/git-bug/git-bug)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/the-git-bug/Lobby)
 
 </div>
@@ -38,7 +38,7 @@ Individually, those pieces are not especially complex but doing everything make 
 
 <details><summary>Pre-compiled binaries</summary>
 
-1. Go to the [release page](https://github.com/MichaelMure/git-bug/releases/latest) and download the appropriate binary for your system.
+1. Go to the [release page](https://github.com/git-bug/git-bug/releases/latest) and download the appropriate binary for your system.
 2. Copy the binary anywhere in your $PATH
 3. Rename the binary to `git-bug` (or `git-bug.exe` on windows)
 
@@ -88,7 +88,7 @@ Or from the ports collection
 <details><summary>Compile from git (unstable)</summary>
 
 ```shell
-git clone https://github.com/MichaelMure/git-bug.git
+git clone https://github.com/git-bug/git-bug.git
 cd git-bug
 make install
 ```
@@ -110,7 +110,7 @@ There are multiple ways to use `git-bug`:
     <img src="misc/diagrams/native_workflow.png" alt="Native workflow">
 </p>
 
-This is the pure `git-bug` experience. In a similar fashion as with code, use `git bug push` and `git bug pull` to push and pull your bugs between git remotes and collaborate with your teammate. 
+This is the pure `git-bug` experience. In a similar fashion as with code, use `git bug push` and `git bug pull` to push and pull your bugs between git remotes and collaborate with your teammate.
 
 </details>
 
@@ -236,7 +236,7 @@ Or manually:
 git bug bridge new \
     --name=<bridge> \
     --target=github \
-    --url=https://github.com/MichaelMure/git-bug \
+    --url=https://github.com/git-bug/git-bug \
     --login=<login> \
     --token=<token>
 ```
@@ -285,7 +285,7 @@ Additional planned feature:
 PRs accepted. Drop by the [Gitter lobby](https://gitter.im/the-git-bug/Lobby) or the [Matrix room](https://matrix.to/#/#the-git-bug_Lobby:gitter.im) for a chat, look at the [feature matrix](doc/feature_matrix.md) or browse the issues to see what is worked on or discussed.
 
 ```shell
-git clone git@github.com:MichaelMure/git-bug.git
+git clone git@github.com:git-bug/git-bug.git
 ```
 
 You can now run `make` to build the project, or `make install` to install the binary in `$GOPATH/bin/`.
@@ -303,7 +303,7 @@ go test ./commands -update
 ## Contributors :heart:
 
 This project exists thanks to all the people who contribute.
-<a href="https://github.com/MichaelMure/git-bug/graphs/contributors"><img src="https://opencollective.com/git-bug/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/git-bug/git-bug/graphs/contributors"><img src="https://opencollective.com/git-bug/contributors.svg?width=890&button=false" /></a>
 
 
 ## Backers

--- a/api/auth/context.go
+++ b/api/auth/context.go
@@ -4,8 +4,8 @@ package auth
 import (
 	"context"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entity"
 )
 
 // identityCtxKey is a unique context key, accessible only in this package.

--- a/api/auth/middleware.go
+++ b/api/auth/middleware.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"net/http"
 
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/entity"
 )
 
 func Middleware(fixedUserId entity.Id) func(http.Handler) http.Handler {

--- a/api/graphql/connections/connection_template.go
+++ b/api/graphql/connections/connection_template.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cheekybits/genny/generic"
 
-	"github.com/MichaelMure/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/api/graphql/models"
 )
 
 // Name define the name of the connection

--- a/api/graphql/connections/edges.go
+++ b/api/graphql/connections/edges.go
@@ -1,6 +1,6 @@
 package connections
 
-import "github.com/MichaelMure/git-bug/entity"
+import "github.com/git-bug/git-bug/entity"
 
 // LazyBugEdge is a special relay edge used to implement a lazy loading connection
 type LazyBugEdge struct {

--- a/api/graphql/connections/gen_comment.go
+++ b/api/graphql/connections/gen_comment.go
@@ -7,8 +7,8 @@ package connections
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
 )
 
 // BugCommentEdgeMaker define a function that take a bug.Comment and an offset and

--- a/api/graphql/connections/gen_identity.go
+++ b/api/graphql/connections/gen_identity.go
@@ -7,7 +7,7 @@ package connections
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/api/graphql/models"
 )
 
 // IdentityEdgeMaker define a function that take a models.IdentityWrapper and an offset and

--- a/api/graphql/connections/gen_label.go
+++ b/api/graphql/connections/gen_label.go
@@ -7,8 +7,8 @@ package connections
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
 )
 
 // BugLabelEdgeMaker define a function that take a bug.Label and an offset and

--- a/api/graphql/connections/gen_lazy_bug.go
+++ b/api/graphql/connections/gen_lazy_bug.go
@@ -7,8 +7,8 @@ package connections
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entity"
 )
 
 // LazyBugEdgeMaker define a function that take a entity.Id and an offset and

--- a/api/graphql/connections/gen_lazy_identity.go
+++ b/api/graphql/connections/gen_lazy_identity.go
@@ -7,8 +7,8 @@ package connections
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entity"
 )
 
 // LazyIdentityEdgeMaker define a function that take a entity.Id and an offset and

--- a/api/graphql/connections/gen_operation.go
+++ b/api/graphql/connections/gen_operation.go
@@ -7,8 +7,8 @@ package connections
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entity/dag"
 )
 
 // DagOperationEdgeMaker define a function that take a dag.Operation and an offset and

--- a/api/graphql/connections/gen_timeline.go
+++ b/api/graphql/connections/gen_timeline.go
@@ -7,8 +7,8 @@ package connections
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
 )
 
 // BugTimelineItemEdgeMaker define a function that take a bug.TimelineItem and an offset and

--- a/api/graphql/gqlgen.yml
+++ b/api/graphql/gqlgen.yml
@@ -7,22 +7,22 @@ model:
   filename: models/gen_models.go
 
 autobind:
-  - "github.com/MichaelMure/git-bug/api/graphql/models"
-  - "github.com/MichaelMure/git-bug/repository"
-  - "github.com/MichaelMure/git-bug/entity"
-  - "github.com/MichaelMure/git-bug/entity/dag"
-  - "github.com/MichaelMure/git-bug/entities/common"
-  - "github.com/MichaelMure/git-bug/entities/bug"
-  - "github.com/MichaelMure/git-bug/entities/identity"
+  - "github.com/git-bug/git-bug/api/graphql/models"
+  - "github.com/git-bug/git-bug/repository"
+  - "github.com/git-bug/git-bug/entity"
+  - "github.com/git-bug/git-bug/entity/dag"
+  - "github.com/git-bug/git-bug/entities/common"
+  - "github.com/git-bug/git-bug/entities/bug"
+  - "github.com/git-bug/git-bug/entities/identity"
 
 omit_getters: true
 
 models:
   ID:
-    model: github.com/MichaelMure/git-bug/entity.Id
+    model: github.com/git-bug/git-bug/entity.Id
   Color:
     model: image/color.RGBA
   Identity:
-    model: github.com/MichaelMure/git-bug/api/graphql/models.IdentityWrapper
+    model: github.com/git-bug/git-bug/api/graphql/models.IdentityWrapper
   Bug:
-    model: github.com/MichaelMure/git-bug/api/graphql/models.BugWrapper
+    model: github.com/git-bug/git-bug/api/graphql/models.BugWrapper

--- a/api/graphql/graph/bug.generated.go
+++ b/api/graphql/graph/bug.generated.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 

--- a/api/graphql/graph/identity.generated.go
+++ b/api/graphql/graph/identity.generated.go
@@ -11,8 +11,8 @@ import (
 	"sync/atomic"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entity"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 

--- a/api/graphql/graph/label.generated.go
+++ b/api/graphql/graph/label.generated.go
@@ -12,8 +12,8 @@ import (
 	"sync/atomic"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 

--- a/api/graphql/graph/mutations.generated.go
+++ b/api/graphql/graph/mutations.generated.go
@@ -11,8 +11,8 @@ import (
 	"sync/atomic"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 

--- a/api/graphql/graph/operations.generated.go
+++ b/api/graphql/graph/operations.generated.go
@@ -12,12 +12,12 @@ import (
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 

--- a/api/graphql/graph/prelude.generated.go
+++ b/api/graphql/graph/prelude.generated.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/entity"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 

--- a/api/graphql/graph/repository.generated.go
+++ b/api/graphql/graph/repository.generated.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/api/graphql/models"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 

--- a/api/graphql/graph/root.generated.go
+++ b/api/graphql/graph/root.generated.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/api/graphql/models"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 

--- a/api/graphql/graph/root_.generated.go
+++ b/api/graphql/graph/root_.generated.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/api/graphql/models"
 	gqlparser "github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
 )

--- a/api/graphql/graph/timeline.generated.go
+++ b/api/graphql/graph/timeline.generated.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 

--- a/api/graphql/graph/types.generated.go
+++ b/api/graphql/graph/types.generated.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 

--- a/api/graphql/graphql_test.go
+++ b/api/graphql/graphql_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/misc/random_bugs"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/misc/random_bugs"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func TestQueries(t *testing.T) {

--- a/api/graphql/handler.go
+++ b/api/graphql/handler.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/99designs/gqlgen/graphql/handler"
 
-	"github.com/MichaelMure/git-bug/api/graphql/graph"
-	"github.com/MichaelMure/git-bug/api/graphql/resolvers"
-	"github.com/MichaelMure/git-bug/cache"
+	"github.com/git-bug/git-bug/api/graphql/graph"
+	"github.com/git-bug/git-bug/api/graphql/resolvers"
+	"github.com/git-bug/git-bug/cache"
 )
 
 // Handler is the root GraphQL http handler

--- a/api/graphql/models/gen_models.go
+++ b/api/graphql/models/gen_models.go
@@ -3,9 +3,9 @@
 package models
 
 import (
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // An object that has an author.

--- a/api/graphql/models/lazy_bug.go
+++ b/api/graphql/models/lazy_bug.go
@@ -4,11 +4,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
 )
 
 // BugWrapper is an interface used by the GraphQL resolvers to handle a bug.

--- a/api/graphql/models/lazy_identity.go
+++ b/api/graphql/models/lazy_identity.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
 )
 
 // IdentityWrapper is an interface used by the GraphQL resolvers to handle an identity.

--- a/api/graphql/models/models.go
+++ b/api/graphql/models/models.go
@@ -2,7 +2,7 @@
 package models
 
 import (
-	"github.com/MichaelMure/git-bug/cache"
+	"github.com/git-bug/git-bug/cache"
 )
 
 type ConnectionInput struct {

--- a/api/graphql/resolvers/bug.go
+++ b/api/graphql/resolvers/bug.go
@@ -3,11 +3,11 @@ package resolvers
 import (
 	"context"
 
-	"github.com/MichaelMure/git-bug/api/graphql/connections"
-	"github.com/MichaelMure/git-bug/api/graphql/graph"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/api/graphql/connections"
+	"github.com/git-bug/git-bug/api/graphql/graph"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entity/dag"
 )
 
 var _ graph.BugResolver = &bugResolver{}

--- a/api/graphql/resolvers/color.go
+++ b/api/graphql/resolvers/color.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"image/color"
 
-	"github.com/MichaelMure/git-bug/api/graphql/graph"
+	"github.com/git-bug/git-bug/api/graphql/graph"
 )
 
 var _ graph.ColorResolver = &colorResolver{}

--- a/api/graphql/resolvers/comment.go
+++ b/api/graphql/resolvers/comment.go
@@ -3,10 +3,10 @@ package resolvers
 import (
 	"context"
 
-	"github.com/MichaelMure/git-bug/api/graphql/graph"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/api/graphql/graph"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entity"
 )
 
 var _ graph.CommentResolver = &commentResolver{}

--- a/api/graphql/resolvers/identity.go
+++ b/api/graphql/resolvers/identity.go
@@ -3,8 +3,8 @@ package resolvers
 import (
 	"context"
 
-	"github.com/MichaelMure/git-bug/api/graphql/graph"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/api/graphql/graph"
+	"github.com/git-bug/git-bug/api/graphql/models"
 )
 
 var _ graph.IdentityResolver = &identityResolver{}

--- a/api/graphql/resolvers/label.go
+++ b/api/graphql/resolvers/label.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"image/color"
 
-	"github.com/MichaelMure/git-bug/api/graphql/graph"
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/api/graphql/graph"
+	"github.com/git-bug/git-bug/entities/bug"
 )
 
 var _ graph.LabelResolver = &labelResolver{}

--- a/api/graphql/resolvers/mutation.go
+++ b/api/graphql/resolvers/mutation.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/MichaelMure/git-bug/api/auth"
-	"github.com/MichaelMure/git-bug/api/graphql/graph"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/api/auth"
+	"github.com/git-bug/git-bug/api/graphql/graph"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 var _ graph.MutationResolver = &mutationResolver{}

--- a/api/graphql/resolvers/operations.go
+++ b/api/graphql/resolvers/operations.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/MichaelMure/git-bug/api/graphql/graph"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/api/graphql/graph"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
 )
 
 var _ graph.CreateOperationResolver = createOperationResolver{}

--- a/api/graphql/resolvers/query.go
+++ b/api/graphql/resolvers/query.go
@@ -3,9 +3,9 @@ package resolvers
 import (
 	"context"
 
-	"github.com/MichaelMure/git-bug/api/graphql/graph"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/cache"
+	"github.com/git-bug/git-bug/api/graphql/graph"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/cache"
 )
 
 var _ graph.QueryResolver = &rootQueryResolver{}

--- a/api/graphql/resolvers/repo.go
+++ b/api/graphql/resolvers/repo.go
@@ -3,13 +3,13 @@ package resolvers
 import (
 	"context"
 
-	"github.com/MichaelMure/git-bug/api/auth"
-	"github.com/MichaelMure/git-bug/api/graphql/connections"
-	"github.com/MichaelMure/git-bug/api/graphql/graph"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/query"
+	"github.com/git-bug/git-bug/api/auth"
+	"github.com/git-bug/git-bug/api/graphql/connections"
+	"github.com/git-bug/git-bug/api/graphql/graph"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/query"
 )
 
 var _ graph.RepositoryResolver = &repoResolver{}

--- a/api/graphql/resolvers/root.go
+++ b/api/graphql/resolvers/root.go
@@ -2,8 +2,8 @@
 package resolvers
 
 import (
-	"github.com/MichaelMure/git-bug/api/graphql/graph"
-	"github.com/MichaelMure/git-bug/cache"
+	"github.com/git-bug/git-bug/api/graphql/graph"
+	"github.com/git-bug/git-bug/cache"
 )
 
 var _ graph.ResolverRoot = &RootResolver{}

--- a/api/graphql/resolvers/timeline.go
+++ b/api/graphql/resolvers/timeline.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/MichaelMure/git-bug/api/graphql/graph"
-	"github.com/MichaelMure/git-bug/api/graphql/models"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/api/graphql/graph"
+	"github.com/git-bug/git-bug/api/graphql/models"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entity"
 )
 
 var _ graph.CommentHistoryStepResolver = commentHistoryStepResolver{}

--- a/api/graphql/tracer.go
+++ b/api/graphql/tracer.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 
-	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/git-bug/git-bug/util/colors"
 )
 
 // adapted from https://github.com/99designs/gqlgen/blob/master/graphql/handler/debug/tracer.go

--- a/api/http/git_file_handler.go
+++ b/api/http/git_file_handler.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // implement a http.Handler that will read and server git blob.

--- a/api/http/git_file_handlers_test.go
+++ b/api/http/git_file_handlers_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/api/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/api/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func TestGitFileHandlers(t *testing.T) {

--- a/api/http/git_file_upload_handler.go
+++ b/api/http/git_file_upload_handler.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/MichaelMure/git-bug/api/auth"
-	"github.com/MichaelMure/git-bug/cache"
+	"github.com/git-bug/git-bug/api/auth"
+	"github.com/git-bug/git-bug/cache"
 )
 
 // implement a http.Handler that will accept and store content into git blob.

--- a/bridge/bridges.go
+++ b/bridge/bridges.go
@@ -2,13 +2,13 @@
 package bridge
 
 import (
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/github"
-	"github.com/MichaelMure/git-bug/bridge/gitlab"
-	"github.com/MichaelMure/git-bug/bridge/jira"
-	"github.com/MichaelMure/git-bug/bridge/launchpad"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/github"
+	"github.com/git-bug/git-bug/bridge/gitlab"
+	"github.com/git-bug/git-bug/bridge/jira"
+	"github.com/git-bug/git-bug/bridge/launchpad"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func init() {

--- a/bridge/core/auth/credential.go
+++ b/bridge/core/auth/credential.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 const (

--- a/bridge/core/auth/credential_base.go
+++ b/bridge/core/auth/credential_base.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/repository"
 )
 
 type credentialBase struct {

--- a/bridge/core/auth/credential_test.go
+++ b/bridge/core/auth/credential_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func TestCredential(t *testing.T) {

--- a/bridge/core/auth/login.go
+++ b/bridge/core/auth/login.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/entity"
 )
 
 const (

--- a/bridge/core/auth/login_password.go
+++ b/bridge/core/auth/login_password.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/entity"
 )
 
 const (

--- a/bridge/core/auth/token.go
+++ b/bridge/core/auth/token.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/entity"
 )
 
 const (

--- a/bridge/core/bridge.go
+++ b/bridge/core/bridge.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/repository"
 )
 
 var ErrImportNotSupported = errors.New("import is not supported")

--- a/bridge/core/config.go
+++ b/bridge/core/config.go
@@ -3,9 +3,9 @@ package core
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
 )
 
 func FinishConfig(repo *cache.RepoCache, metaKey string, login string) error {

--- a/bridge/core/export.go
+++ b/bridge/core/export.go
@@ -3,7 +3,7 @@ package core
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/entity"
 )
 
 type ExportEvent int

--- a/bridge/core/import.go
+++ b/bridge/core/import.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/entity"
 )
 
 type ImportEvent int

--- a/bridge/core/interfaces.go
+++ b/bridge/core/interfaces.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/MichaelMure/git-bug/cache"
+	"github.com/git-bug/git-bug/cache"
 )
 
 type Configuration map[string]string

--- a/bridge/github/client.go
+++ b/bridge/github/client.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core"
 )
 
 var _ Client = &githubv4.Client{}

--- a/bridge/github/config.go
+++ b/bridge/github/config.go
@@ -15,11 +15,11 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/commands/input"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/commands/input"
+	"github.com/git-bug/git-bug/repository"
 )
 
 const githubClientID = "ce3600aa56c2e69f18a5" // git-bug org

--- a/bridge/github/config_test.go
+++ b/bridge/github/config_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/bridge/core/auth"
 )
 
 func TestSplitURL(t *testing.T) {
@@ -26,10 +26,10 @@ func TestSplitURL(t *testing.T) {
 		{
 			name: "default url",
 			args: args{
-				url: "https://github.com/MichaelMure/git-bug",
+				url: "https://github.com/git-bug/git-bug",
 			},
 			want: want{
-				owner:   "MichaelMure",
+				owner:   "git-bug",
 				project: "git-bug",
 				err:     nil,
 			},
@@ -37,10 +37,10 @@ func TestSplitURL(t *testing.T) {
 		{
 			name: "default issues url",
 			args: args{
-				url: "https://github.com/MichaelMure/git-bug/issues",
+				url: "https://github.com/git-bug/git-bug/issues",
 			},
 			want: want{
-				owner:   "MichaelMure",
+				owner:   "git-bug",
 				project: "git-bug",
 				err:     nil,
 			},
@@ -48,10 +48,10 @@ func TestSplitURL(t *testing.T) {
 		{
 			name: "default url with git extension",
 			args: args{
-				url: "https://github.com/MichaelMure/git-bug.git",
+				url: "https://github.com/git-bug/git-bug.git",
 			},
 			want: want{
-				owner:   "MichaelMure",
+				owner:   "git-bug",
 				project: "git-bug",
 				err:     nil,
 			},
@@ -59,10 +59,10 @@ func TestSplitURL(t *testing.T) {
 		{
 			name: "url with git protocol",
 			args: args{
-				url: "git://github.com/MichaelMure/git-bug.git",
+				url: "git://github.com/git-bug/git-bug.git",
 			},
 			want: want{
-				owner:   "MichaelMure",
+				owner:   "git-bug",
 				project: "git-bug",
 				err:     nil,
 			},
@@ -70,10 +70,10 @@ func TestSplitURL(t *testing.T) {
 		{
 			name: "ssh url",
 			args: args{
-				url: "git@github.com:MichaelMure/git-bug.git",
+				url: "git@github.com:git-bug/git-bug.git",
 			},
 			want: want{
-				owner:   "MichaelMure",
+				owner:   "git-bug",
 				project: "git-bug",
 				err:     nil,
 			},
@@ -81,7 +81,7 @@ func TestSplitURL(t *testing.T) {
 		{
 			name: "bad url",
 			args: args{
-				url: "https://githb.com/MichaelMure/git-bug.git",
+				url: "https://githb.com/git-bug/git-bug.git",
 			},
 			want: want{
 				err: ErrBadProjectURL,
@@ -115,26 +115,26 @@ func TestValidateUsername(t *testing.T) {
 	}{
 		{
 			name:  "existing username",
-			input: "MichaelMure",
-			fixed: "MichaelMure",
+			input: "git-bug",
+			fixed: "git-bug",
 			ok:    true,
 		},
 		{
 			name:  "existing username with bad case",
-			input: "MicHaelmurE",
-			fixed: "MichaelMure",
+			input: "GiT-bUg",
+			fixed: "git-bug",
 			ok:    true,
 		},
 		{
 			name:  "existing organisation",
-			input: "ipfs",
-			fixed: "ipfs",
+			input: "git-bug",
+			fixed: "git-bug",
 			ok:    true,
 		},
 		{
 			name:  "existing organisation with bad case",
-			input: "iPfS",
-			fixed: "ipfs",
+			input: "gIt-BuG",
+			fixed: "git-bug",
 			ok:    true,
 		},
 		{
@@ -183,7 +183,7 @@ func TestValidateProject(t *testing.T) {
 			name: "public repository and token with scope 'public_repo'",
 			args: args{
 				project: "git-bug",
-				owner:   "MichaelMure",
+				owner:   "git-bug",
 				token:   tokenPublic,
 			},
 			want: true,
@@ -192,7 +192,7 @@ func TestValidateProject(t *testing.T) {
 			name: "private repository and token with scope 'repo'",
 			args: args{
 				project: "git-bug-test-github-bridge",
-				owner:   "MichaelMure",
+				owner:   "git-bug",
 				token:   tokenPrivate,
 			},
 			want: true,
@@ -201,7 +201,7 @@ func TestValidateProject(t *testing.T) {
 			name: "private repository and token with scope 'public_repo'",
 			args: args{
 				project: "git-bug-test-github-bridge",
-				owner:   "MichaelMure",
+				owner:   "git-bug",
 				token:   tokenPublic,
 			},
 			want: false,

--- a/bridge/github/export.go
+++ b/bridge/github/export.go
@@ -15,13 +15,13 @@ import (
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
 )
 
 var (

--- a/bridge/github/export_test.go
+++ b/bridge/github/export_test.go
@@ -13,13 +13,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/interrupt"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/interrupt"
 )
 
 const (

--- a/bridge/github/github.go
+++ b/bridge/github/github.go
@@ -7,8 +7,8 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
 )
 
 const (

--- a/bridge/github/import.go
+++ b/bridge/github/import.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/shurcooL/githubv4"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 const EmptyTitlePlaceholder = "<empty string>"

--- a/bridge/github/import_integration_test.go
+++ b/bridge/github/import_integration_test.go
@@ -11,11 +11,11 @@ import (
 	m "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/bridge/github/mocks"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/interrupt"
+	"github.com/git-bug/git-bug/bridge/github/mocks"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/interrupt"
 )
 
 // using testify/mock and mockery

--- a/bridge/github/import_test.go
+++ b/bridge/github/import_test.go
@@ -4,20 +4,21 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/interrupt"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/interrupt"
 )
 
 func TestGithubImporter(t *testing.T) {
@@ -34,7 +35,10 @@ func TestGithubImporter(t *testing.T) {
 	defer backend.Close()
 	interrupt.RegisterCleaner(backend.Close)
 
-	author, err := identity.NewIdentity(repo, "Michael Muré", "batolettre@gmail.com")
+	author, err := identity.NewIdentity(repo, "Michael Muré", "no-reply@git-bug.test")
+	require.NoError(t, err)
+
+	complexIssueEditAuthor, err := identity.NewIdentity(repo, "sudoforge", "no-reply@git-bug.test")
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -44,7 +48,7 @@ func TestGithubImporter(t *testing.T) {
 	}{
 		{
 			name: "simple issue",
-			url:  "https://github.com/MichaelMure/git-bug-test-github-bridge/issues/1",
+			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/1",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "simple issue", "initial comment", nil),
@@ -55,7 +59,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "empty issue",
-			url:  "https://github.com/MichaelMure/git-bug-test-github-bridge/issues/2",
+			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/2",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "empty issue", "", nil),
@@ -64,14 +68,41 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "complex issue",
-			url:  "https://github.com/MichaelMure/git-bug-test-github-bridge/issues/3",
+			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/3",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "complex issue", "initial comment", nil),
 					bug.NewLabelChangeOperation(author, 0, []bug.Label{"bug"}, []bug.Label{}),
 					bug.NewLabelChangeOperation(author, 0, []bug.Label{"duplicate"}, []bug.Label{}),
 					bug.NewLabelChangeOperation(author, 0, []bug.Label{}, []bug.Label{"duplicate"}),
-					bug.NewAddCommentOp(author, 0, "### header\n\n**bold**\n\n_italic_\n\n> with quote\n\n`inline code`\n\n```\nmultiline code\n```\n\n- bulleted\n- list\n\n1. numbered\n1. list\n\n- [ ] task\n- [x] list\n\n@MichaelMure mention\n\n#2 reference issue\n#3 auto-reference issue\n\n![image](https://user-images.githubusercontent.com/294669/56870222-811faf80-6a0c-11e9-8f2c-f0beb686303f.png)", nil),
+					bug.NewAddCommentOp(author, 0, strings.Join([]string{
+						"### header",
+						"**bold**",
+						"_italic_",
+						"> with quote",
+						"`inline code`",
+						"```\nmultiline code\n```",
+						"- bulleted\n- list",
+						"1. numbered\n1. list",
+						"- [ ] task\n- [x] list",
+						"@MichaelMure mention",
+						"#2 reference issue\n#3 auto-reference issue",
+						"![image](https://user-images.githubusercontent.com/294669/56870222-811faf80-6a0c-11e9-8f2c-f0beb686303f.png)",
+					}, "\n\n"), nil),
+					bug.NewEditCommentOp(complexIssueEditAuthor, 0, "", strings.Join([]string{
+						"### header",
+						"**bold**",
+						"_italic_",
+						"> with quote",
+						"`inline code`",
+						"```\nmultiline code\n```",
+						"- bulleted\n- list",
+						"1. numbered\n1. list",
+						"- [ ] task\n- [x] list",
+						"@git-bug/maintainers mention",
+						"#2 reference issue\n#3 auto-reference issue",
+						"![image](https://user-images.githubusercontent.com/294669/56870222-811faf80-6a0c-11e9-8f2c-f0beb686303f.png)",
+					}, "\n\n"), nil),
 					bug.NewSetTitleOp(author, 0, "complex issue edited", "complex issue"),
 					bug.NewSetTitleOp(author, 0, "complex issue", "complex issue edited"),
 					bug.NewSetStatusOp(author, 0, common.ClosedStatus),
@@ -81,7 +112,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "editions",
-			url:  "https://github.com/MichaelMure/git-bug-test-github-bridge/issues/4",
+			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/4",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "editions", "initial comment edited", nil),
@@ -93,7 +124,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "comment deletion",
-			url:  "https://github.com/MichaelMure/git-bug-test-github-bridge/issues/5",
+			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/5",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "comment deletion", "", nil),
@@ -102,7 +133,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "edition deletion",
-			url:  "https://github.com/MichaelMure/git-bug-test-github-bridge/issues/6",
+			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/6",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "edition deletion", "initial comment", nil),
@@ -114,7 +145,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "hidden comment",
-			url:  "https://github.com/MichaelMure/git-bug-test-github-bridge/issues/7",
+			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/7",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "hidden comment", "initial comment", nil),
@@ -124,7 +155,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "transferred issue",
-			url:  "https://github.com/MichaelMure/git-bug-test-github-bridge/issues/8",
+			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/8",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "transfered issue", "", nil),
@@ -133,7 +164,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "unicode control characters",
-			url:  "https://github.com/MichaelMure/git-bug-test-github-bridge/issues/10",
+			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/10",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "unicode control characters", "u0000: \nu0001: \nu0002: \nu0003: \nu0004: \nu0005: \nu0006: \nu0007: \nu0008: \nu0009: \t\nu0010: \nu0011: \nu0012: \nu0013: \nu0014: \nu0015: \nu0016: \nu0017: \nu0018: \nu0019:", nil),
@@ -154,7 +185,7 @@ func TestGithubImporter(t *testing.T) {
 
 	importer := &githubImporter{}
 	err = importer.Init(ctx, backend, core.Configuration{
-		confKeyOwner:        "MichaelMure",
+		confKeyOwner:        "git-bug",
 		confKeyProject:      "git-bug-test-github-bridge",
 		confKeyDefaultLogin: login,
 	})

--- a/bridge/gitlab/config.go
+++ b/bridge/gitlab/config.go
@@ -10,11 +10,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/xanzy/go-gitlab"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/commands/input"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/commands/input"
+	"github.com/git-bug/git-bug/repository"
 )
 
 var (

--- a/bridge/gitlab/config_test.go
+++ b/bridge/gitlab/config_test.go
@@ -22,57 +22,57 @@ func TestProjectPath(t *testing.T) {
 		{
 			name: "default url",
 			args: args{
-				url: "https://gitlab.com/MichaelMure/git-bug",
+				url: "https://gitlab.com/git-bug/git-bug",
 			},
 			want: want{
-				path: "MichaelMure/git-bug",
+				path: "git-bug/git-bug",
 				err:  nil,
 			},
 		},
 		{
 			name: "multiple sub groups",
 			args: args{
-				url: "https://gitlab.com/MichaelMure/group/subgroup/git-bug",
+				url: "https://gitlab.com/git-bug/group/subgroup/git-bug",
 			},
 			want: want{
-				path: "MichaelMure/group/subgroup/git-bug",
+				path: "git-bug/group/subgroup/git-bug",
 				err:  nil,
 			},
 		},
 		{
 			name: "default url with git extension",
 			args: args{
-				url: "https://gitlab.com/MichaelMure/git-bug.git",
+				url: "https://gitlab.com/git-bug/git-bug.git",
 			},
 			want: want{
-				path: "MichaelMure/git-bug",
+				path: "git-bug/git-bug",
 				err:  nil,
 			},
 		},
 		{
 			name: "url with git protocol",
 			args: args{
-				url: "git://gitlab.com/MichaelMure/git-bug.git",
+				url: "git://gitlab.com/git-bug/git-bug.git",
 			},
 			want: want{
-				path: "MichaelMure/git-bug",
+				path: "git-bug/git-bug",
 				err:  nil,
 			},
 		},
 		{
 			name: "ssh url",
 			args: args{
-				url: "git@gitlab.com/MichaelMure/git-bug.git",
+				url: "git@gitlab.com/git-bug/git-bug.git",
 			},
 			want: want{
-				path: "MichaelMure/git-bug",
+				path: "git-bug/git-bug",
 				err:  nil,
 			},
 		},
 		{
 			name: "bad url",
 			args: args{
-				url: "---,%gitlab.com/MichaelMure/git-bug.git",
+				url: "---,%gitlab.com/git-bug/git-bug.git",
 			},
 			want: want{
 				err: ErrBadProjectURL,

--- a/bridge/gitlab/event.go
+++ b/bridge/gitlab/event.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/xanzy/go-gitlab"
 
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 // Event represents a unified GitLab event (note, label or state event).

--- a/bridge/gitlab/export.go
+++ b/bridge/gitlab/export.go
@@ -10,13 +10,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/xanzy/go-gitlab"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
 )
 
 var (

--- a/bridge/gitlab/export_test.go
+++ b/bridge/gitlab/export_test.go
@@ -11,16 +11,16 @@ import (
 
 	"github.com/xanzy/go-gitlab"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/interrupt"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/interrupt"
 )
 
 const (

--- a/bridge/gitlab/gitlab.go
+++ b/bridge/gitlab/gitlab.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/xanzy/go-gitlab"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
 )
 
 const (

--- a/bridge/gitlab/gitlab_api.go
+++ b/bridge/gitlab/gitlab_api.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/util/text"
 	"github.com/xanzy/go-gitlab"
 )
 

--- a/bridge/gitlab/import.go
+++ b/bridge/gitlab/import.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/xanzy/go-gitlab"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 // gitlabImporter implement the Importer interface

--- a/bridge/gitlab/import_test.go
+++ b/bridge/gitlab/import_test.go
@@ -9,15 +9,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/interrupt"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/interrupt"
 )
 
 func TestGitlabImport(t *testing.T) {
@@ -73,7 +73,7 @@ func TestGitlabImport(t *testing.T) {
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "complex issue", "initial comment", nil),
-					bug.NewAddCommentOp(author, 0, "### header\n\n**bold**\n\n_italic_\n\n> with quote\n\n`inline code`\n\n```\nmultiline code\n```\n\n- bulleted\n- list\n\n1. numbered\n1. list\n\n- [ ] task\n- [x] list\n\n@MichaelMure mention\n\n#2 reference issue\n#3 auto-reference issue", nil),
+					bug.NewAddCommentOp(author, 0, "### header\n\n**bold**\n\n_italic_\n\n> with quote\n\n`inline code`\n\n```\nmultiline code\n```\n\n- bulleted\n- list\n\n1. numbered\n1. list\n\n- [ ] task\n- [x] list\n\n@git-bug mention\n\n#2 reference issue\n#3 auto-reference issue", nil),
 					bug.NewSetTitleOp(author, 0, "complex issue edited", "complex issue"),
 					bug.NewSetTitleOp(author, 0, "complex issue", "complex issue edited"),
 					bug.NewSetStatusOp(author, 0, common.ClosedStatus),

--- a/bridge/jira/client.go
+++ b/bridge/jira/client.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/bug"
 )
 
 var errDone = errors.New("Iteration Done")

--- a/bridge/jira/config.go
+++ b/bridge/jira/config.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/commands/input"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/commands/input"
+	"github.com/git-bug/git-bug/repository"
 )
 
 const moreConfigText = `
 NOTE: There are a few optional configuration values that you can additionally
 set in your git configuration to influence the behavior of the bridge. Please
 see the notes at:
-https://github.com/MichaelMure/git-bug/blob/master/doc/jira_bridge.md
+https://github.com/git-bug/git-bug/blob/master/doc/jira_bridge.md
 `
 
 const credTypeText = `

--- a/bridge/jira/export.go
+++ b/bridge/jira/export.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
 )
 
 var (

--- a/bridge/jira/import.go
+++ b/bridge/jira/import.go
@@ -9,14 +9,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 const (

--- a/bridge/jira/jira.go
+++ b/bridge/jira/jira.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/commands/input"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/commands/input"
 )
 
 const (

--- a/bridge/launchpad/config.go
+++ b/bridge/launchpad/config.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/commands/input"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/commands/input"
 )
 
 var ErrBadProjectURL = errors.New("bad Launchpad project URL")

--- a/bridge/launchpad/import.go
+++ b/bridge/launchpad/import.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 type launchpadImporter struct {

--- a/bridge/launchpad/launchpad.go
+++ b/bridge/launchpad/launchpad.go
@@ -4,7 +4,7 @@ package launchpad
 import (
 	"time"
 
-	"github.com/MichaelMure/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core"
 )
 
 const (

--- a/cache/bug_cache.go
+++ b/cache/bug_cache.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
 )
 
 var ErrNoMatchingOp = fmt.Errorf("no matching operation found")

--- a/cache/bug_excerpt.go
+++ b/cache/bug_excerpt.go
@@ -4,10 +4,10 @@ import (
 	"encoding/gob"
 	"time"
 
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/util/lamport"
 )
 
 // Package initialisation used to register the type for (de)serialization

--- a/cache/bug_subcache.go
+++ b/cache/bug_subcache.go
@@ -5,11 +5,11 @@ import (
 	"sort"
 	"time"
 
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/query"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/query"
+	"github.com/git-bug/git-bug/repository"
 )
 
 type RepoCacheBug struct {

--- a/cache/cached.go
+++ b/cache/cached.go
@@ -3,10 +3,10 @@ package cache
 import (
 	"sync"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/lamport"
 )
 
 var _ CacheEntity = &CachedEntityBase[dag.Snapshot, dag.Operation]{}

--- a/cache/filter.go
+++ b/cache/filter.go
@@ -3,9 +3,9 @@ package cache
 import (
 	"strings"
 
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/query"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/query"
 )
 
 // Filter is a predicate that match a subset of bugs

--- a/cache/identity_cache.go
+++ b/cache/identity_cache.go
@@ -3,9 +3,9 @@ package cache
 import (
 	"sync"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 var _ identity.Interface = &IdentityCache{}

--- a/cache/identity_excerpt.go
+++ b/cache/identity_excerpt.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/entity"
 )
 
 // Package initialisation used to register the type for (de)serialization

--- a/cache/identity_subcache.go
+++ b/cache/identity_subcache.go
@@ -3,9 +3,9 @@ package cache
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 type RepoCacheIdentity struct {

--- a/cache/lru_id_cache.go
+++ b/cache/lru_id_cache.go
@@ -5,7 +5,7 @@ import (
 
 	lru "github.com/hashicorp/golang-lru/v2"
 
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/entity"
 )
 
 type lruIdCache struct {

--- a/cache/multi_repo_cache.go
+++ b/cache/multi_repo_cache.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/repository"
 )
 
 const lockfile = "lock"

--- a/cache/repo_cache.go
+++ b/cache/repo_cache.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/multierr"
-	"github.com/MichaelMure/git-bug/util/process"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/multierr"
+	"github.com/git-bug/git-bug/util/process"
 )
 
 // 1: original format

--- a/cache/repo_cache_common.go
+++ b/cache/repo_cache_common.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/multierr"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/multierr"
 )
 
 func (c *RepoCache) Name() string {

--- a/cache/repo_cache_test.go
+++ b/cache/repo_cache_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/query"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/query"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func TestCache(t *testing.T) {
@@ -331,7 +331,7 @@ func TestCacheEviction(t *testing.T) {
 }
 
 func TestLongDescription(t *testing.T) {
-	// See https://github.com/MichaelMure/git-bug/issues/606
+	// See https://github.com/git-bug/git-bug/issues/606
 
 	text := strings.Repeat("x", 65536)
 

--- a/cache/subcache.go
+++ b/cache/subcache.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 type Excerpt interface {

--- a/cache/with_snapshot.go
+++ b/cache/with_snapshot.go
@@ -3,8 +3,8 @@ package cache
 import (
 	"sync"
 
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
 )
 
 var _ dag.Interface[dag.Snapshot, dag.OperationWithApply[dag.Snapshot]] = &withSnapshot[dag.Snapshot, dag.OperationWithApply[dag.Snapshot]]{}

--- a/commands/bridge/bridge.go
+++ b/commands/bridge/bridge.go
@@ -3,8 +3,8 @@ package bridgecmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/bridge"
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/bridge"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func NewBridgeCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bridge/bridge_auth.go
+++ b/commands/bridge/bridge_auth.go
@@ -7,9 +7,9 @@ import (
 	text "github.com/MichaelMure/go-term-text"
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/util/colors"
 )
 
 func newBridgeAuthCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bridge/bridge_auth_addtoken.go
+++ b/commands/bridge/bridge_auth_addtoken.go
@@ -10,12 +10,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/bridge"
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/bridge"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 type bridgeAuthAddTokenOptions struct {

--- a/commands/bridge/bridge_auth_rm.go
+++ b/commands/bridge/bridge_auth_rm.go
@@ -3,9 +3,9 @@ package bridgecmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newBridgeAuthRm(env *execenv.Env) *cobra.Command {

--- a/commands/bridge/bridge_auth_show.go
+++ b/commands/bridge/bridge_auth_show.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newBridgeAuthShow(env *execenv.Env) *cobra.Command {

--- a/commands/bridge/bridge_new.go
+++ b/commands/bridge/bridge_new.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/bridge"
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/bridge"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/repository"
 )
 
 type bridgeNewOptions struct {
@@ -43,8 +43,7 @@ target: 1
 name [default]: default
 
 Detected projects:
-[1]: github.com/a-hilaly/git-bug
-[2]: github.com/MichaelMure/git-bug
+[1]: github.com/git-bug/git-bug
 
 [0]: Another project
 
@@ -70,9 +69,9 @@ Successfully configured bridge: default
 git bug bridge new \
     --name=default \
     --target=github \
-    --owner=$(OWNER) \
-    --project=$(PROJECT) \
-    --token=$(TOKEN)
+    --owner=example-owner
+    --project=example-repo \
+    --token=$TOKEN
 
 # For Launchpad
 git bug bridge new \
@@ -83,9 +82,9 @@ git bug bridge new \
 # For Gitlab
 git bug bridge new \
     --name=default \
-    --target=github \
-    --url=https://github.com/michaelmure/git-bug \
-    --token=$(TOKEN)`,
+    --target=gitlab \
+    --url=https://github.com/example-org/example-repo \
+    --token=$TOKEN`,
 		PreRunE: execenv.LoadBackend(env),
 		RunE: execenv.CloseBackend(env, func(cmd *cobra.Command, args []string) error {
 			return runBridgeNew(env, options)

--- a/commands/bridge/bridge_pull.go
+++ b/commands/bridge/bridge_pull.go
@@ -11,11 +11,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/bridge"
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/util/interrupt"
+	"github.com/git-bug/git-bug/bridge"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/util/interrupt"
 )
 
 type bridgePullOptions struct {

--- a/commands/bridge/bridge_push.go
+++ b/commands/bridge/bridge_push.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/bridge"
-	"github.com/MichaelMure/git-bug/bridge/core"
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/util/interrupt"
+	"github.com/git-bug/git-bug/bridge"
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/util/interrupt"
 )
 
 func newBridgePushCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bridge/bridge_rm.go
+++ b/commands/bridge/bridge_rm.go
@@ -3,9 +3,9 @@ package bridgecmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/bridge"
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/bridge"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newBridgeRm(env *execenv.Env) *cobra.Command {

--- a/commands/bug/bug.go
+++ b/commands/bug/bug.go
@@ -9,15 +9,15 @@ import (
 	text "github.com/MichaelMure/go-term-text"
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/commands/cmdjson"
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/query"
-	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/commands/cmdjson"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/query"
+	"github.com/git-bug/git-bug/util/colors"
 )
 
 type bugOptions struct {

--- a/commands/bug/bug_comment.go
+++ b/commands/bug/bug_comment.go
@@ -4,8 +4,8 @@ import (
 	text "github.com/MichaelMure/go-term-text"
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/util/colors"
 )
 
 func newBugCommentCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bug/bug_comment_add.go
+++ b/commands/bug/bug_comment_add.go
@@ -3,9 +3,9 @@ package bugcmd
 import (
 	"github.com/spf13/cobra"
 
-	buginput "github.com/MichaelMure/git-bug/commands/bug/input"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/util/text"
+	buginput "github.com/git-bug/git-bug/commands/bug/input"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 type bugCommentNewOptions struct {

--- a/commands/bug/bug_comment_add_test.go
+++ b/commands/bug/bug_comment_add_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/commands/bug/testenv"
+	"github.com/git-bug/git-bug/commands/bug/testenv"
 )
 
 func TestBugCommentNew(t *testing.T) {

--- a/commands/bug/bug_comment_edit.go
+++ b/commands/bug/bug_comment_edit.go
@@ -3,8 +3,8 @@ package bugcmd
 import (
 	"github.com/spf13/cobra"
 
-	buginput "github.com/MichaelMure/git-bug/commands/bug/input"
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	buginput "github.com/git-bug/git-bug/commands/bug/input"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 type bugCommentEditOptions struct {

--- a/commands/bug/bug_comment_edit_test.go
+++ b/commands/bug/bug_comment_edit_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/commands/bug/testenv"
+	"github.com/git-bug/git-bug/commands/bug/testenv"
 )
 
 func TestBugCommentEdit(t *testing.T) {

--- a/commands/bug/bug_comment_test.go
+++ b/commands/bug/bug_comment_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/commands/bug/testenv"
-	"github.com/MichaelMure/git-bug/commands/cmdtest"
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/bug/testenv"
+	"github.com/git-bug/git-bug/commands/cmdtest"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func TestBugComment(t *testing.T) {

--- a/commands/bug/bug_deselect.go
+++ b/commands/bug/bug_deselect.go
@@ -3,9 +3,9 @@ package bugcmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	_select "github.com/MichaelMure/git-bug/commands/select"
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/commands/execenv"
+	_select "github.com/git-bug/git-bug/commands/select"
+	"github.com/git-bug/git-bug/entities/bug"
 )
 
 func newBugDeselectCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bug/bug_label.go
+++ b/commands/bug/bug_label.go
@@ -3,7 +3,7 @@ package bugcmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newBugLabelCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bug/bug_label_new.go
+++ b/commands/bug/bug_label_new.go
@@ -3,8 +3,8 @@ package bugcmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 func newBugLabelNewCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bug/bug_label_rm.go
+++ b/commands/bug/bug_label_rm.go
@@ -3,8 +3,8 @@ package bugcmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 func newBugLabelRmCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bug/bug_new.go
+++ b/commands/bug/bug_new.go
@@ -3,9 +3,9 @@ package bugcmd
 import (
 	"github.com/spf13/cobra"
 
-	buginput "github.com/MichaelMure/git-bug/commands/bug/input"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/util/text"
+	buginput "github.com/git-bug/git-bug/commands/bug/input"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 type bugNewOptions struct {

--- a/commands/bug/bug_new_test.go
+++ b/commands/bug/bug_new_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/commands/bug/testenv"
+	"github.com/git-bug/git-bug/commands/bug/testenv"
 )
 
 func TestBugNew(t *testing.T) {

--- a/commands/bug/bug_rm.go
+++ b/commands/bug/bug_rm.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newBugRmCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bug/bug_rm_test.go
+++ b/commands/bug/bug_rm_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/commands/bug/testenv"
+	"github.com/git-bug/git-bug/commands/bug/testenv"
 )
 
 func TestBugRm(t *testing.T) {

--- a/commands/bug/bug_select.go
+++ b/commands/bug/bug_select.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	_select "github.com/MichaelMure/git-bug/commands/select"
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/commands/execenv"
+	_select "github.com/git-bug/git-bug/commands/select"
+	"github.com/git-bug/git-bug/entities/bug"
 )
 
 func ResolveSelected(repo *cache.RepoCache, args []string) (*cache.BugCache, []string, error) {

--- a/commands/bug/bug_show.go
+++ b/commands/bug/bug_show.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/cmdjson"
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/git-bug/git-bug/commands/cmdjson"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/util/colors"
 )
 
 type bugShowOptions struct {

--- a/commands/bug/bug_status.go
+++ b/commands/bug/bug_status.go
@@ -3,7 +3,7 @@ package bugcmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newBugStatusCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bug/bug_status_close.go
+++ b/commands/bug/bug_status_close.go
@@ -3,7 +3,7 @@ package bugcmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newBugStatusCloseCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bug/bug_status_open.go
+++ b/commands/bug/bug_status_open.go
@@ -3,7 +3,7 @@ package bugcmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newBugStatusOpenCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bug/bug_test.go
+++ b/commands/bug/bug_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/commands/bug/testenv"
-	. "github.com/MichaelMure/git-bug/commands/cmdtest"
+	"github.com/git-bug/git-bug/commands/bug/testenv"
+	. "github.com/git-bug/git-bug/commands/cmdtest"
 )
 
 func Test_repairQuery(t *testing.T) {

--- a/commands/bug/bug_title.go
+++ b/commands/bug/bug_title.go
@@ -3,7 +3,7 @@ package bugcmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newBugTitleCommand(env *execenv.Env) *cobra.Command {

--- a/commands/bug/bug_title_edit.go
+++ b/commands/bug/bug_title_edit.go
@@ -3,9 +3,9 @@ package bugcmd
 import (
 	"github.com/spf13/cobra"
 
-	buginput "github.com/MichaelMure/git-bug/commands/bug/input"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/util/text"
+	buginput "github.com/git-bug/git-bug/commands/bug/input"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 type bugTitleEditOptions struct {

--- a/commands/bug/completion.go
+++ b/commands/bug/completion.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	_select "github.com/MichaelMure/git-bug/commands/select"
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
+	_select "github.com/git-bug/git-bug/commands/select"
+	"github.com/git-bug/git-bug/entities/bug"
 )
 
 // BugCompletion complete a bug id

--- a/commands/bug/input/input.go
+++ b/commands/bug/input/input.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/commands/input"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/commands/input"
+	"github.com/git-bug/git-bug/repository"
 )
 
 const messageFilename = "BUG_MESSAGE_EDITMSG"

--- a/commands/bug/testenv/testenv.go
+++ b/commands/bug/testenv/testenv.go
@@ -6,8 +6,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/entity"
 )
 
 const (
@@ -28,7 +28,7 @@ func NewTestEnvAndUser(t *testing.T) (*execenv.Env, entity.Id) {
 	// git-bug command output is consistent in all test scenarios.
 	//
 	// See:
-	// - https://github.com/MichaelMure/git-bug/issues/926
+	// - https://github.com/git-bug/git-bug/issues/926
 	// - https://github.com/golang/go/issues/57671
 	// - https://github.com/golang/go/blob/f721fa3be9bb52524f97b409606f9423437535e8/src/cmd/go/internal/test/test.go#L1180-L1208
 	// - https://github.com/golang/go/issues/34877

--- a/commands/cmdjson/bug.go
+++ b/commands/cmdjson/bug.go
@@ -1,8 +1,8 @@
 package cmdjson
 
 import (
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
 )
 
 type BugSnapshot struct {

--- a/commands/cmdjson/json_common.go
+++ b/commands/cmdjson/json_common.go
@@ -3,9 +3,9 @@ package cmdjson
 import (
 	"time"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/util/lamport"
 )
 
 type Identity struct {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 type commandOptions struct {

--- a/commands/completion/helper_completion.go
+++ b/commands/completion/helper_completion.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/bridge"
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/bridge"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 type ValidArgsFunction func(cmd *cobra.Command, args []string, toComplete string) (completions []string, directives cobra.ShellCompDirective)

--- a/commands/execenv/env.go
+++ b/commands/execenv/env.go
@@ -9,8 +9,8 @@ import (
 	"github.com/mattn/go-isatty"
 	"golang.org/x/term"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/repository"
 )
 
 const RootCommandName = "git-bug"

--- a/commands/execenv/env_testing.go
+++ b/commands/execenv/env_testing.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/repository"
 )
 
 var _ In = &TestIn{}

--- a/commands/execenv/loading.go
+++ b/commands/execenv/loading.go
@@ -8,10 +8,10 @@ import (
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/interrupt"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/interrupt"
 )
 
 // LoadRepo is a pre-run function that load the repository for use in a command

--- a/commands/input/input.go
+++ b/commands/input/input.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/go-git/go-billy/v5/util"
 
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // LaunchEditorWithTemplate will launch an editor as LaunchEditor do, but with a

--- a/commands/input/prompt.go
+++ b/commands/input/prompt.go
@@ -13,9 +13,9 @@ import (
 
 	"golang.org/x/crypto/ssh/terminal"
 
-	"github.com/MichaelMure/git-bug/bridge/core/auth"
-	"github.com/MichaelMure/git-bug/util/colors"
-	"github.com/MichaelMure/git-bug/util/interrupt"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/util/colors"
+	"github.com/git-bug/git-bug/util/interrupt"
 )
 
 // PromptValidator is a validator for a user entry

--- a/commands/label.go
+++ b/commands/label.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newLabelCommand(env *execenv.Env) *cobra.Command {

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/entity"
 )
 
 func newPullCommand(env *execenv.Env) *cobra.Command {

--- a/commands/push.go
+++ b/commands/push.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newPushCommand(env *execenv.Env) *cobra.Command {

--- a/commands/root.go
+++ b/commands/root.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	bridgecmd "github.com/MichaelMure/git-bug/commands/bridge"
-	bugcmd "github.com/MichaelMure/git-bug/commands/bug"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	usercmd "github.com/MichaelMure/git-bug/commands/user"
+	bridgecmd "github.com/git-bug/git-bug/commands/bridge"
+	bugcmd "github.com/git-bug/git-bug/commands/bug"
+	"github.com/git-bug/git-bug/commands/execenv"
+	usercmd "github.com/git-bug/git-bug/commands/user"
 )
 
 // These variables are initialized externally during the build. See the Makefile.

--- a/commands/select/select.go
+++ b/commands/select/select.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entity"
 )
 
 type ErrNoValidId struct {

--- a/commands/select/select_test.go
+++ b/commands/select/select_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func TestSelect(t *testing.T) {

--- a/commands/termui.go
+++ b/commands/termui.go
@@ -3,8 +3,8 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/termui"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/termui"
 )
 
 func newTermUICommand(env *execenv.Env) *cobra.Command {

--- a/commands/user/user.go
+++ b/commands/user/user.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/commands/cmdjson"
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/commands/cmdjson"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/util/colors"
 )
 
 type userOptions struct {

--- a/commands/user/user_adopt.go
+++ b/commands/user/user_adopt.go
@@ -3,8 +3,8 @@ package usercmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newUserAdoptCommand(env *execenv.Env) *cobra.Command {

--- a/commands/user/user_new.go
+++ b/commands/user/user_new.go
@@ -3,8 +3,8 @@ package usercmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/commands/input"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/input"
 )
 
 type userNewOptions struct {

--- a/commands/user/user_new_test.go
+++ b/commands/user/user_new_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/commands/bug/testenv"
+	"github.com/git-bug/git-bug/commands/bug/testenv"
 )
 
 func TestUserNewCommand(t *testing.T) {

--- a/commands/user/user_show.go
+++ b/commands/user/user_show.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/commands/completion"
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/commands/completion"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 type userShowOptions struct {

--- a/commands/version.go
+++ b/commands/version.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 type versionOptions struct {

--- a/commands/webui.go
+++ b/commands/webui.go
@@ -21,14 +21,14 @@ import (
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/api/auth"
-	"github.com/MichaelMure/git-bug/api/graphql"
-	httpapi "github.com/MichaelMure/git-bug/api/http"
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/commands/execenv"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/webui"
+	"github.com/git-bug/git-bug/api/auth"
+	"github.com/git-bug/git-bug/api/graphql"
+	httpapi "github.com/git-bug/git-bug/api/http"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/webui"
 )
 
 const webUIOpenConfigKey = "git-bug.webui.open"

--- a/commands/wipe.go
+++ b/commands/wipe.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands/execenv"
+	"github.com/git-bug/git-bug/commands/execenv"
 )
 
 func newWipeCommand(env *execenv.Env) *cobra.Command {

--- a/doc/feature_matrix.md
+++ b/doc/feature_matrix.md
@@ -18,7 +18,7 @@ Some goals don't really fit below, so I'll mention them here:
 - privileged roles (admin, ...) and enforcing the corresponding rules
 - package the webui as a desktop app
 
-Additionally, some other are captured as [Github issues](https://github.com/MichaelMure/git-bug/issues) or [Discussions](https://github.com/MichaelMure/git-bug/discussions). 
+Additionally, some other are captured as [Github issues](https://github.com/git-bug/git-bug/issues) or [Discussions](https://github.com/git-bug/git-bug/discussions). 
 
 ## Entities
 

--- a/doc/gen_docs.go
+++ b/doc/gen_docs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 
-	"github.com/MichaelMure/git-bug/commands"
+	"github.com/git-bug/git-bug/commands"
 )
 
 func main() {

--- a/doc/howto-github.md
+++ b/doc/howto-github.md
@@ -1,6 +1,6 @@
 # How-to: Read and edit offline your Github/Gitlab/Jira issues with git-bug
 
-[git-bug](https://github.com/MichaelMure/git-bug) is a standalone distributed bug-tracker that is embedded in git. In short, if you have a git repository you can use it to store bugs alongside your code (without mixing them though!), push and pull them to/from a normal git remote to collaborate.
+[git-bug](https://github.com/git-bug/git-bug) is a standalone distributed bug-tracker that is embedded in git. In short, if you have a git repository you can use it to store bugs alongside your code (without mixing them though!), push and pull them to/from a normal git remote to collaborate.
 
 <p align="center">
     <img src="../misc/diagrams/native_workflow.png" alt="Native workflow">
@@ -22,7 +22,7 @@ Note: at the moment, Gitlab and Jira are also fully supported.
 
 ## Installation
 
-Follow the [installation instruction](https://github.com/MichaelMure/git-bug#installation). The simplest way is to download a pre-compiled binary from [the latest release](https://github.com/MichaelMure/git-bug/releases/latest) and to put it anywhere in your `$PATH`.
+Follow the [installation instruction](https://github.com/git-bug/git-bug#installation). The simplest way is to download a pre-compiled binary from [the latest release](https://github.com/git-bug/git-bug/releases/latest) and to put it anywhere in your `$PATH`.
 
 Check that `git-bug` is properly installed by running `git bug version`. If everything is alright, the version of the binary will be displayed.
 
@@ -31,7 +31,7 @@ Check that `git-bug` is properly installed by running `git bug version`. If ever
 1. From within the git repository you care about, run `git bug bridge configure` and follow the wizard's steps:
     1. Choose `github`.
     1. Type a name for the bridge configuration. As you can configure multiple bridges, this name will allow you to choose when there is an ambiguity.
-    1. Setup the remote Github project. The wizard is smart enough to inspect the git remote and detect the potential project. Otherwise, enter the project URL like this: `https://github.com/MichaelMure/git-bug`
+    1. Setup the remote Github project. The wizard is smart enough to inspect the git remote and detect the potential project. Otherwise, enter the project URL like this: `https://github.com/git-bug/git-bug`
     1. Enter your login on Github
     1. Setup an authentication token. You can either use the interactive token creation, enter your own token or select an existing token, if any.
 1. Run `git bug bridge pull` and let it run to import the issues and identities.
@@ -73,8 +73,8 @@ For a richer and more user friendly UI, `git-bug` proposes a web UI (read-only a
 ## Want more?
 
 If you interested to read more about `git-bug`, have a look at the following:
-- [the project itself, with a more complete readme](https://github.com/MichaelMure/git-bug)
-- [a bird view of the internals](https://github.com/MichaelMure/git-bug/blob/master/doc/architecture.md)
-- [a description of the data model](https://github.com/MichaelMure/git-bug/blob/master/doc/model.md)
+- [the project itself, with a more complete readme](https://github.com/git-bug/git-bug)
+- [a bird view of the internals](https://github.com/git-bug/git-bug/blob/master/doc/architecture.md)
+- [a description of the data model](https://github.com/git-bug/git-bug/blob/master/doc/model.md)
 
 Of course, if you want to contribute the door is way open :-)

--- a/doc/man/git-bug-bridge-new.1
+++ b/doc/man/git-bug-bridge-new.1
@@ -82,7 +82,7 @@ name [default]: default
 
 Detected projects:
 [1]: github.com/a-hilaly/git-bug
-[2]: github.com/MichaelMure/git-bug
+[2]: github.com/git-bug/git-bug
 
 [0]: Another project
 
@@ -122,7 +122,7 @@ git bug bridge new \\
 git bug bridge new \\
     --name=default \\
     --target=github \\
-    --url=https://github.com/michaelmure/git-bug \\
+    --url=https://gitlab.com/git-bug/git-bug \\
     --token=$(TOKEN)
 
 .fi

--- a/doc/md/git-bug_bridge_new.md
+++ b/doc/md/git-bug_bridge_new.md
@@ -24,7 +24,7 @@ name [default]: default
 
 Detected projects:
 [1]: github.com/a-hilaly/git-bug
-[2]: github.com/MichaelMure/git-bug
+[2]: github.com/git-bug/git-bug
 
 [0]: Another project
 
@@ -63,8 +63,8 @@ git bug bridge new \
 # For Gitlab
 git bug bridge new \
     --name=default \
-    --target=github \
-    --url=https://github.com/michaelmure/git-bug \
+    --target=gitlab \
+    --url=https://gitlab.com/git-bug/git-bug \
     --token=$(TOKEN)
 ```
 

--- a/entities/bug/bug.go
+++ b/entities/bug/bug.go
@@ -4,11 +4,11 @@ package bug
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
 )
 
 var _ Interface = &Bug{}

--- a/entities/bug/bug_actions.go
+++ b/entities/bug/bug_actions.go
@@ -1,10 +1,10 @@
 package bug
 
 import (
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // Fetch retrieve updates from a remote

--- a/entities/bug/comment.go
+++ b/entities/bug/comment.go
@@ -3,10 +3,10 @@ package bug
 import (
 	"github.com/dustin/go-humanize"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/timestamp"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/timestamp"
 )
 
 // Comment represent a comment in a Bug

--- a/entities/bug/label.go
+++ b/entities/bug/label.go
@@ -7,7 +7,7 @@ import (
 
 	fcolor "github.com/fatih/color"
 
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 type Label string

--- a/entities/bug/op_add_comment.go
+++ b/entities/bug/op_add_comment.go
@@ -3,12 +3,12 @@ package bug
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/text"
-	"github.com/MichaelMure/git-bug/util/timestamp"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/text"
+	"github.com/git-bug/git-bug/util/timestamp"
 )
 
 var _ Operation = &AddCommentOperation{}

--- a/entities/bug/op_add_comment_test.go
+++ b/entities/bug/op_add_comment_test.go
@@ -3,10 +3,10 @@ package bug
 import (
 	"testing"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func TestAddCommentSerialize(t *testing.T) {

--- a/entities/bug/op_create.go
+++ b/entities/bug/op_create.go
@@ -3,12 +3,12 @@ package bug
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/text"
-	"github.com/MichaelMure/git-bug/util/timestamp"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/text"
+	"github.com/git-bug/git-bug/util/timestamp"
 )
 
 var _ Operation = &CreateOperation{}

--- a/entities/bug/op_create_test.go
+++ b/entities/bug/op_create_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func TestCreate(t *testing.T) {

--- a/entities/bug/op_edit_comment.go
+++ b/entities/bug/op_edit_comment.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/timestamp"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/timestamp"
 
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 var _ Operation = &EditCommentOperation{}

--- a/entities/bug/op_edit_comment_test.go
+++ b/entities/bug/op_edit_comment_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func TestEdit(t *testing.T) {

--- a/entities/bug/op_label_change.go
+++ b/entities/bug/op_label_change.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/util/timestamp"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/util/timestamp"
 )
 
 var _ Operation = &LabelChangeOperation{}

--- a/entities/bug/op_label_change_test.go
+++ b/entities/bug/op_label_change_test.go
@@ -3,9 +3,9 @@ package bug
 import (
 	"testing"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
 )
 
 func TestLabelChangeSerialize(t *testing.T) {

--- a/entities/bug/op_set_metadata.go
+++ b/entities/bug/op_set_metadata.go
@@ -1,9 +1,9 @@
 package bug
 
 import (
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
 )
 
 func NewSetMetadataOp(author identity.Interface, unixTime int64, target entity.Id, newMetadata map[string]string) *dag.SetMetadataOperation[*Snapshot] {

--- a/entities/bug/op_set_status.go
+++ b/entities/bug/op_set_status.go
@@ -3,11 +3,11 @@ package bug
 import (
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/util/timestamp"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/util/timestamp"
 )
 
 var _ Operation = &SetStatusOperation{}

--- a/entities/bug/op_set_status_test.go
+++ b/entities/bug/op_set_status_test.go
@@ -3,10 +3,10 @@ package bug
 import (
 	"testing"
 
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
 )
 
 func TestSetStatusSerialize(t *testing.T) {

--- a/entities/bug/op_set_title.go
+++ b/entities/bug/op_set_title.go
@@ -3,12 +3,12 @@ package bug
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/util/timestamp"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/util/timestamp"
 
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 var _ Operation = &SetTitleOperation{}

--- a/entities/bug/op_set_title_test.go
+++ b/entities/bug/op_set_title_test.go
@@ -3,9 +3,9 @@ package bug
 import (
 	"testing"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
 )
 
 func TestSetTitleSerialize(t *testing.T) {

--- a/entities/bug/operation.go
+++ b/entities/bug/operation.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
 )
 
 const (

--- a/entities/bug/operation_test.go
+++ b/entities/bug/operation_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // TODO: move to entity/dag?

--- a/entities/bug/resolver.go
+++ b/entities/bug/resolver.go
@@ -1,8 +1,8 @@
 package bug
 
 import (
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 var _ entity.Resolver = &SimpleResolver{}

--- a/entities/bug/snapshot.go
+++ b/entities/bug/snapshot.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
 )
 
 var _ dag.Snapshot = &Snapshot{}

--- a/entities/bug/timeline.go
+++ b/entities/bug/timeline.go
@@ -3,10 +3,10 @@ package bug
 import (
 	"strings"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/timestamp"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/timestamp"
 )
 
 type TimelineItem interface {

--- a/entities/identity/identity.go
+++ b/entities/identity/identity.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/lamport"
-	"github.com/MichaelMure/git-bug/util/timestamp"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/util/timestamp"
 )
 
 const identityRefPattern = "refs/identities/"

--- a/entities/identity/identity_actions.go
+++ b/entities/identity/identity_actions.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // Fetch retrieve updates from a remote

--- a/entities/identity/identity_actions_test.go
+++ b/entities/identity/identity_actions_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func TestIdentityPushPull(t *testing.T) {

--- a/entities/identity/identity_stub.go
+++ b/entities/identity/identity_stub.go
@@ -3,10 +3,10 @@ package identity
 import (
 	"encoding/json"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/lamport"
-	"github.com/MichaelMure/git-bug/util/timestamp"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/util/timestamp"
 )
 
 var _ Interface = &IdentityStub{}

--- a/entities/identity/identity_test.go
+++ b/entities/identity/identity_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/lamport"
 )
 
 // Test the commit and load of an Identity with multiple versions

--- a/entities/identity/identity_user.go
+++ b/entities/identity/identity_user.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // SetUserIdentity store the user identity's id in the git config

--- a/entities/identity/interface.go
+++ b/entities/identity/interface.go
@@ -1,10 +1,10 @@
 package identity
 
 import (
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/lamport"
-	"github.com/MichaelMure/git-bug/util/timestamp"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/util/timestamp"
 )
 
 type Interface interface {

--- a/entities/identity/key.go
+++ b/entities/identity/key.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/repository"
 )
 
 var errNoPrivateKey = fmt.Errorf("no private key")

--- a/entities/identity/key_test.go
+++ b/entities/identity/key_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func TestPublicKeyJSON(t *testing.T) {

--- a/entities/identity/resolver.go
+++ b/entities/identity/resolver.go
@@ -1,8 +1,8 @@
 package identity
 
 import (
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 var _ entity.Resolver = &SimpleResolver{}

--- a/entities/identity/version.go
+++ b/entities/identity/version.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/lamport"
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 // 1: original format

--- a/entities/identity/version_test.go
+++ b/entities/identity/version_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/lamport"
 )
 
 func makeIdentityTestRepo(t *testing.T) repository.ClockedRepo {

--- a/entity/dag/clock.go
+++ b/entity/dag/clock.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // ClockLoader is the repository.ClockLoader for Entity

--- a/entity/dag/common_test.go
+++ b/entity/dag/common_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // This file contains an example dummy entity to be used in the tests

--- a/entity/dag/entity.go
+++ b/entity/dag/entity.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/lamport"
 )
 
 const refsPattern = "refs/%s/%s"

--- a/entity/dag/entity_actions.go
+++ b/entity/dag/entity_actions.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // ListLocalIds list all the available local Entity's Id

--- a/entity/dag/entity_actions_test.go
+++ b/entity/dag/entity_actions_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func allEntities(t testing.TB, bugs <-chan entity.StreamedEntity[*Foo]) []*Foo {

--- a/entity/dag/example_test.go
+++ b/entity/dag/example_test.go
@@ -6,14 +6,14 @@ import (
 	"os"
 	"time"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/entity/dag"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // Note: you can find explanations about the underlying data model here:
-// https://github.com/MichaelMure/git-bug/blob/master/doc/model.md
+// https://github.com/git-bug/git-bug/blob/master/doc/model.md
 
 // This file explains how to define a replicated data structure, stored in and using git as a medium for
 // synchronisation. To do this, we'll use the entity/dag package, which will do all the complex handling.

--- a/entity/dag/interface.go
+++ b/entity/dag/interface.go
@@ -1,9 +1,9 @@
 package dag
 
 import (
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/lamport"
 )
 
 // Interface define the extended interface of a dag.Entity

--- a/entity/dag/op_noop.go
+++ b/entity/dag/op_noop.go
@@ -1,8 +1,8 @@
 package dag
 
 import (
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
 )
 
 var _ Operation = &NoOpOperation[Snapshot]{}

--- a/entity/dag/op_noop_test.go
+++ b/entity/dag/op_noop_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
 )
 
 func TestNoopSerialize(t *testing.T) {

--- a/entity/dag/op_set_metadata.go
+++ b/entity/dag/op_set_metadata.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 var _ Operation = &SetMetadataOperation[Snapshot]{}

--- a/entity/dag/op_set_metadata_test.go
+++ b/entity/dag/op_set_metadata_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 
 	"github.com/stretchr/testify/require"
 )

--- a/entity/dag/operation.go
+++ b/entity/dag/operation.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // OperationType is an operation type identifier

--- a/entity/dag/operation_pack.go
+++ b/entity/dag/operation_pack.go
@@ -9,10 +9,10 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/lamport"
 )
 
 const opsEntryName = "ops"

--- a/entity/dag/operation_pack_test.go
+++ b/entity/dag/operation_pack_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func TestOperationPackReadWrite(t *testing.T) {

--- a/entity/dag/operation_testing.go
+++ b/entity/dag/operation_testing.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // SerializeRoundTripTest realize a marshall/unmarshall round-trip in the same condition as with OperationPack,

--- a/entity/err.go
+++ b/entity/err.go
@@ -75,10 +75,10 @@ func NewErrUnknownFormat(expected uint) *ErrInvalidFormat {
 
 func (e ErrInvalidFormat) Error() string {
 	if e.version == 0 {
-		return fmt.Sprintf("unreadable data, you likely have an outdated repository format, please use https://github.com/MichaelMure/git-bug-migration to upgrade to format version %v", e.expected)
+		return fmt.Sprintf("unreadable data, you likely have an outdated repository format, please use https://github.com/git-bug/git-bug-migration to upgrade to format version %v", e.expected)
 	}
 	if e.version < e.expected {
-		return fmt.Sprintf("outdated repository format %v, please use https://github.com/MichaelMure/git-bug-migration to upgrade to format version %v", e.version, e.expected)
+		return fmt.Sprintf("outdated repository format %v, please use https://github.com/git-bug/git-bug-migration to upgrade to format version %v", e.version, e.expected)
 	}
 	return fmt.Sprintf("your version of git-bug is too old for this repository (format version %v, expected %v), please upgrade to the latest version", e.version, e.expected)
 }

--- a/entity/id.go
+++ b/entity/id.go
@@ -67,7 +67,7 @@ func (i Id) MarshalGQL(w io.Writer) {
 func (i Id) Validate() error {
 	// Special case to detect outdated repo
 	if len(i) == 40 {
-		return fmt.Errorf("outdated repository format, please use https://github.com/MichaelMure/git-bug-migration to upgrade")
+		return fmt.Errorf("outdated repository format, please use https://github.com/git-bug/git-bug-migration to upgrade")
 	}
 	if len(i) != idLength {
 		return fmt.Errorf("invalid length")

--- a/entity/id_interleaved.go
+++ b/entity/id_interleaved.go
@@ -55,7 +55,7 @@ func (ci CombinedId) MarshalGQL(w io.Writer) {
 func (ci CombinedId) Validate() error {
 	// Special case to detect outdated repo
 	if len(ci) == 40 {
-		return fmt.Errorf("outdated repository format, please use https://github.com/MichaelMure/git-bug-migration to upgrade")
+		return fmt.Errorf("outdated repository format, please use https://github.com/git-bug/git-bug-migration to upgrade")
 	}
 	if len(ci) != idLength {
 		return fmt.Errorf("invalid length")

--- a/git-bug.go
+++ b/git-bug.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"github.com/MichaelMure/git-bug/commands"
+	"github.com/git-bug/git-bug/commands"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/MichaelMure/git-bug
+module github.com/git-bug/git-bug
 
 go 1.22.5
 

--- a/misc/completion/gen_completion.go
+++ b/misc/completion/gen_completion.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/MichaelMure/git-bug/commands"
+	"github.com/git-bug/git-bug/commands"
 )
 
 func main() {

--- a/misc/random_bugs/cmd/main.go
+++ b/misc/random_bugs/cmd/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"os"
 
-	"github.com/MichaelMure/git-bug/entities/bug"
-	rb "github.com/MichaelMure/git-bug/misc/random_bugs"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/bug"
+	rb "github.com/git-bug/git-bug/misc/random_bugs"
+	"github.com/git-bug/git-bug/repository"
 )
 
 // This program will randomly generate a collection of bugs in the repository

--- a/misc/random_bugs/create_random_bugs.go
+++ b/misc/random_bugs/create_random_bugs.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/icrowley/fake"
 
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/identity"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/identity"
+	"github.com/git-bug/git-bug/repository"
 )
 
 type opsGenerator func(bug.Interface, identity.Interface, int64)

--- a/query/parser.go
+++ b/query/parser.go
@@ -3,7 +3,7 @@ package query
 import (
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entities/common"
 )
 
 // Parse parse a query DSL

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entities/common"
 )
 
 func TestParse(t *testing.T) {

--- a/query/query.go
+++ b/query/query.go
@@ -1,7 +1,7 @@
 package query
 
 import (
-	"github.com/MichaelMure/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entities/common"
 )
 
 // Query is the intermediary representation of a Bug's query. It is either

--- a/repository/gogit.go
+++ b/repository/gogit.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/execabs"
 
-	"github.com/MichaelMure/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/util/lamport"
 )
 
 const clockPath = "clocks"

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/go-git/go-billy/v5/memfs"
 
-	"github.com/MichaelMure/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/util/lamport"
 )
 
 var _ ClockedRepo = &mockRepo{}
@@ -115,7 +115,7 @@ func (r *mockRepoCommon) GetCoreEditor() (string, error) {
 // GetRemotes returns the configured remotes repositories.
 func (r *mockRepoCommon) GetRemotes() (map[string]string, error) {
 	return map[string]string{
-		"origin": "git://github.com/MichaelMure/git-bug",
+		"origin": "git://github.com/git-bug/git-bug",
 	}, nil
 }
 

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/go-git/go-billy/v5"
 
-	"github.com/MichaelMure/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/util/lamport"
 )
 
 var (

--- a/repository/repo_testing.go
+++ b/repository/repo_testing.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/MichaelMure/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/util/lamport"
 )
 
 type RepoCreator func(t testing.TB, bare bool) TestedRepo

--- a/termui/bug_table.go
+++ b/termui/bug_table.go
@@ -10,10 +10,10 @@ import (
 	"github.com/awesome-gocui/gocui"
 	"github.com/dustin/go-humanize"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/query"
-	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/query"
+	"github.com/git-bug/git-bug/util/colors"
 )
 
 const bugTableView = "bugTableView"

--- a/termui/help_bar.go
+++ b/termui/help_bar.go
@@ -6,7 +6,7 @@ import (
 
 	text "github.com/MichaelMure/go-term-text"
 
-	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/git-bug/git-bug/util/colors"
 )
 
 type helpBar []struct {

--- a/termui/label_select.go
+++ b/termui/label_select.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/awesome-gocui/gocui"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
 )
 
 const labelSelectView = "labelSelectView"

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -9,11 +9,11 @@ import (
 	text "github.com/MichaelMure/go-term-text"
 	"github.com/awesome-gocui/gocui"
 
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/entities/common"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/util/colors"
 )
 
 const showBugView = "showBugView"

--- a/termui/termui.go
+++ b/termui/termui.go
@@ -7,11 +7,11 @@ import (
 	"github.com/awesome-gocui/gocui"
 	"github.com/pkg/errors"
 
-	"github.com/MichaelMure/git-bug/cache"
-	buginput "github.com/MichaelMure/git-bug/commands/bug/input"
-	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/query"
-	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/git-bug/git-bug/cache"
+	buginput "github.com/git-bug/git-bug/commands/bug/input"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/query"
+	"github.com/git-bug/git-bug/util/text"
 )
 
 var errTerminateMainloop = errors.New("terminate gocui mainloop")

--- a/tests/read_bugs_test.go
+++ b/tests/read_bugs_test.go
@@ -3,9 +3,9 @@ package tests
 import (
 	"testing"
 
-	"github.com/MichaelMure/git-bug/entities/bug"
-	"github.com/MichaelMure/git-bug/misc/random_bugs"
-	"github.com/MichaelMure/git-bug/repository"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/misc/random_bugs"
+	"github.com/git-bug/git-bug/repository"
 )
 
 func TestReadBugs(t *testing.T) {

--- a/webui/src/__tests__/query.ts
+++ b/webui/src/__tests__/query.ts
@@ -123,11 +123,9 @@ it('parses a complex query', () => {
 });
 
 it('parses a key:value:value query', () => {
-  expect(parse(`meta:github:"https://github.com/MichaelMure/git-bug"`)).toEqual(
-    {
-      meta: [`github:"https://github.com/MichaelMure/git-bug"`],
-    }
-  );
+  expect(parse(`meta:github:"https://github.com/git-bug/git-bug"`)).toEqual({
+    meta: [`github:"https://github.com/git-bug/git-bug"`],
+  });
 });
 
 it('quotes values', () => {


### PR DESCRIPTION
The repository was recently moved to the git-bug organization on github.
This change refactors references to the repository to ensure that they
use the updated owner URI.

Closes: #1243
Change-Id: I799712354c6ba25cdd8b06286275850c52efe6ff