### PR TITLE
TEMP: disable presubmit pipelines

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -9,12 +9,7 @@
 name: presubmit
 
 on:
-  merge_group:
-    types:
-      - checks_requested
-  pull_request:
-    branches:
-      - master
+  workflow_call:
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,12 +1,7 @@
 name: scan
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-  schedule:
-    - cron: '0 12 * * 6'
+  workflow_call:
 
 permissions:
   security-events: write

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,247 @@
+# Installation Guide
+
+`git-bug` is distributed as a single binary, and is available for:
+
+- [Linux](#linux)
+  - [Arch Linux](#arch-linux)
+  - [NixOS & Nixpkgs](#nix)
+- [FreeBSD](#freebsd)
+- [MacOS](#macos)
+- [Windows](#windows)
+
+You can also [build from source](#from-source) if you prefer, or if `git-bug` is
+not available for your system via your preferred package manager.
+
+<!--
+    NOTE TO CONTRIBUTORS:
+
+    We use HTML elements within <details> in order to avoid parsing errors with
+    GFM caused by triple-backtick blocks or alert elements being nested next to
+    the summary or beginning of the <details> block.
+
+    Please keep this in mind as you make changes.
+-->
+
+## Download a pre-compiled release binary
+
+You can download the latest release binary from [the release page][rel/latest],
+making sure to grab the appropriate binary for your system.
+
+Next, rename the binary to `git-bug`, or `git-bug.exe` if you're using Windows.
+
+Finally, place the binary in a directory that's in your `PATH`. That's it! You
+should now have `git-bug` available as a command line tool.
+
+## <a name="linux"></a> Linux
+
+`git-bug` is available on a variety of Linux distributions, but how you install
+it depends on your distribution and package manager(s), as there is no standard
+package manager common to all distributions.
+
+### <a name="arch-linux"></a> Arch Linux
+
+`git-bug` is available in the [Arch Linux User Repository (AUR)][p/aur].
+
+Below, you'll find a **non-exhaustive** list of commands that use common third
+party tools for installing packages from the AUR.
+
+<details><summary>Using <strong>aurutils</strong></summary>
+<pre>aur sync git-bug-bin && pacman -Syu git-bug-bin</pre>
+</details>
+
+<details><summary>Using <strong>yay</strong></summary>
+<pre>yay -S git-bug-bin</pre>
+</details>
+
+### <a name="nix"></a> Nixpkgs
+
+`git-bug` is available via [nixpkgs][p/nix].
+
+<details><summary>Using <strong>home-manager</strong></summary>
+<pre>
+home.package = with pkgs; [
+  git-bug
+];
+</pre>
+</details>
+
+<details><summary>Using <strong>nix-profile</strong></summary>
+<pre>nix profile install nixpkgs\#git-bug</pre>
+</details>
+
+<details><summary>Using <strong>channels</strong></summary>
+<pre>
+environment.systemPackages = with pkgs; [
+  git-bug
+];
+</pre>
+</details>
+
+---
+
+## <a name="freebsd"></a> FreeBSD
+
+`git-bug` is available through a few different methods.
+
+<details><summary>Using <strong>pkg</strong></summary>
+<pre>pkg install git-bug</pre>
+</details>
+
+<details><summary>Using the <strong>ports</strong> collection</summary>
+<pre>make -C /usr/ports/devel/git-bug install clean</pre>
+</details>
+
+## <a name="macos"></a> MacOS
+
+`git-bug` is shipped via [**Homebrew**][brew.sh]:
+
+```
+brew install git-bug
+```
+
+---
+
+## <a name="windows"></a> Windows
+
+`git-bug` is shipped via `scoop`:
+
+```
+scoop install git-bug
+```
+
+---
+
+## <a name="from-source"></a> Build from source
+
+You can also build `git-bug` from source, if you wish. You'll need the following
+dependencies:
+
+- `git`
+- `go`
+- `make`
+
+Ensure that the `go` binary directory (`$GOPATH/bin`) is in your `PATH`. It is
+recommended to set this within your shell configuration file(s), such as
+`~/.zprofile` or `~/.bashrc`.
+
+```
+export PATH=$PATH:$(go env GOROOT)/bin:$(go env GOPATH)/bin
+```
+
+> [!NOTE]
+> The commands below assume you do not want to keep the repository on disk, and
+> thus clones the repository to a new temporary directory and performs a
+> lightweight clone in order to reduce network latency and data transfer.
+>
+> As a result, the repository cloned during these steps will not contain the
+> full history. If that is important to you, clone the repository using the
+> method you prefer, check out your preferred revision, and run `make install`.
+
+**First, create a new repository on disk:**
+
+```
+cd $(mktemp -d) && git init .
+```
+
+**Next, set the remote to the upstream source:**
+
+```
+git remote add origin git@github.com:git-bug/git-bug.git
+```
+
+Next, choose whether you want to build from a release tag, branch, or
+development head and expand the instructions below.
+
+<details><summary>Build from <strong>a release tag</strong></summary>
+
+First, list all of the tags from the repository (we use `sed` in the command
+below to filter out some unecessary visual noise):
+
+<pre>
+git ls-remote origin refs/tags/\* | sed -e 's/refs\/tags\///'
+</pre>
+
+You'll see output similar to:
+
+<pre>
+c1a08111b603403d4ee0a78c1214f322fecaa3ca        0.1.0
+d959acc29dcbc467790ae87389f9569bb830c8c6        0.2.0
+ad59f77fd425b00ae4b8d7360a64dc3dc1c73bd0        0.3.0
+...
+</pre>
+
+<blockquote><strong>Tip</strong><p>
+The <em>tags</em> are in the right-most column. Old revisions up to and
+including <code>0.7.1</code> do not contain a <em>v</em> prefix, however, all
+revisions after, do.
+</p></blockquote>
+
+Select the tag you wish to build, and fetch it using the command below. Be sure
+to replace <code>REPLACE-ME</code> with the tag you selected:
+
+<pre>
+git fetch --no-tags --depth 1 origin +refs/tags/REPLACE-ME:refs/tags/REPLACE-ME
+</pre>
+
+<blockquote><strong>NOTE</strong><p>
+The <code>--no-tags</code> flag might seem out of place, since we <em>are</em>
+fetching a tag, but it isn't -- the reason we use this is avoid fetching other
+tags, in case you have <code>fetch.pruneTags</code> enabled in your global
+configuration, which causes <code>git</code> to fetch <em>all</em> tags.
+</p></blockquote>
+
+Next, check out the tag, replacing <code>REPLACE-ME</code> with the tag you selected:
+
+<pre>
+git checkout REPLACE-ME
+</pre>
+
+Finally, run the <code>install</code> target from <code>//:Makefile</code>:
+
+<pre>
+make install
+</pre>
+
+This will build <code>git-bug</code> and place it in your Go binary directory.
+</details>
+
+<details>
+<summary>
+Build the <strong>unstable development <code>HEAD</code></strong>
+</summary>
+
+First, fetch the most recent commit for the default branch:
+
+<pre>
+git fetch --no-tags --depth 1 origin HEAD:refs/remotes/origin/HEAD
+</pre>
+
+Next, check out the tree you pulled:
+
+<pre>
+git checkout origin/HEAD
+</pre>
+
+Finally, run the <code>install</code> target from <code>//:Makefile</code>:
+
+<pre>
+make install
+</pre>
+
+This will build <code>git-bug</code> and place it in your Go binary directory.
+</details>
+
+## Verify your installation
+
+To verify that `git-bug` was installed correctly, you can run the following
+command. If you see output similar to what's shown below (and without any
+errors), you're all set!
+
+```
+git bug version
+```
+
+[brew.sh]: https://brew.sh
+[p/aur]: https://aur.archlinux.org/packages/git-bug-bin
+[p/nix]: https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/version-management/git-bug/default.nix
+[rel/latest]: https://github.com/git-bug/git-bug/releases/latest

--- a/README.md
+++ b/README.md
@@ -1,105 +1,57 @@
-<p align="center">
-    <img width="150px" src="https://cdn.rawgit.com/git-bug/git-bug/master/misc/logo/logo-alpha-flat-bg.svg">
-</p>
-<h1 align="center">git-bug</h1>
-
 <div align="center">
+<img width="64px" src="https://cdn.rawgit.com/git-bug/git-bug/master/misc/logo/logo-alpha-flat-bg.svg">
+<h1>git-bug</h1>
 
-[![Backers on Open Collective](https://opencollective.com/git-bug/backers/badge.svg)](#backers)
-[![Sponsors on Open Collective](https://opencollective.com/git-bug/sponsors/badge.svg)](#sponsors)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3+-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
-[![GoDoc](https://godoc.org/github.com/git-bug/git-bug?status.svg)](https://godoc.org/github.com/git-bug/git-bug)
-[![Go Report Card](https://goreportcard.com/badge/github.com/git-bug/git-bug)](https://goreportcard.com/report/github.com/git-bug/git-bug)
-[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/the-git-bug/Lobby)
+[![trunk][ci/badge]][ci/url]
 
+[![Backers on Open Collective][oc/backers/badge]](#backers)
+[![Sponsors on Open Collective][oc/sponsors/badge]](#sponsors)
+[![GPL v3 License][license/badge]][license/url]
+[![GoDoc][godoc/badge]][godoc/url]
+[![Go Report Card][report-card/badge]][report-card/url]
+[![Matrix][matrix/badge]][matrix/url]
 </div>
 
 `git-bug` is a bug tracker that:
 
-- **is fully embedded in git**: you only need your git repository to have a bug tracker
-- **is distributed**: use your normal git remote to collaborate, push and pull your bugs!
-- **works offline**: in a plane or under the sea? Keep reading and writing bugs!
-- **prevents vendor lock-in**: your usual service is down or went bad? You already have a full backup.
+- **is fully embedded in git**: you only need your git repository to have a bug
+  tracker
+- **is distributed**: use your normal git remote to collaborate, push and pull
+  your bugs!
+- **works offline**: no internet connection? Keep reading and writing bugs!
+- **prevents vendor lock-in**: is your usual service down? Good thing your bugs
+  are distributed!
 - **is fast**: listing bugs or opening them is a matter of milliseconds
 - **doesn't pollute your project**: no files are added in your project
-- **integrates with your tooling**: use the UI you like (CLI, terminal, web) or integrate with your existing tools through the CLI or the GraphQL API
-- **bridges to other bug trackers**: use [bridges](#bridges) to import and export to other trackers.
+- **integrates with your tooling**: use the UI you like (CLI, TUI, web) or
+  integrate with your existing tools through the CLI or the GraphQL API
+- **bridges to other bug trackers**: use [bridges](#bridges) to import and
+  export to other trackers.
 
-## Help needed!
+---
 
-This project has grown bigger than I can handle by myself, especially with a day job. I'm looking for people to help on or maintain part of it:
-- each bridges (go)
-- the terminal UI (go)
-- the web UI (Typescript/React/GraphQL)
+<div align="center"><em>
+This project and its vibrant community was initially dreamt up and built
 
-Individually, those pieces are not especially complex but doing everything make it hard for me to focus on the core where things get more complicated. If this is useful for you or you just want to join the fun, maybe consider it?
+by [Michael Muré][mm]. Thank you for all of your hard work!
 
-## Installation
+:heart:
+</em></div>
 
-<details><summary>Pre-compiled binaries</summary>
+---
 
-1. Go to the [release page](https://github.com/git-bug/git-bug/releases/latest) and download the appropriate binary for your system.
-2. Copy the binary anywhere in your $PATH
-3. Rename the binary to `git-bug` (or `git-bug.exe` on windows)
+## Getting started
 
-That's all !
+There are a few different ways to get involved.
 
-</details>
-
-<details><summary>Windows packages</summary>
-
-* [Scoop](https://github.com/ScoopInstaller/Main/blob/master/bucket/git-bug.json)
-  ```
-  scoop install git-bug
-  ```
-
-</details>
-
-<details><summary>Linux packages</summary>
-
-* [Archlinux (AUR)](https://aur.archlinux.org/packages/?K=git-bug)
-* [NixOS](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/version-management/git-and-tools/git-bug/default.nix#L31)
-
-</details>
-
-<details><summary>macOS packages</summary>
-
-* [Homebrew](https://formulae.brew.sh/formula/git-bug)
-  ```
-  brew install git-bug
-  ```
-
-</details>
-
-<details><summary>FreeBSD package/port</summary>
-
-Install via the package manager
-  ```
-  pkg install git-bug
-  ```
-
-Or from the ports collection
-  ```
-  cd /usr/ports/devel/git-bug && make install clean
-  ```
-
-</details>
-
-<details><summary>Compile from git (unstable)</summary>
-
-```shell
-git clone https://github.com/git-bug/git-bug.git
-cd git-bug
-make install
-```
-
-If it's not done already, add the golang binary directory in your PATH:
-
-```bash
-export PATH=$PATH:$(go env GOROOT)/bin:$(go env GOPATH)/bin
-```
-
-</details>
+- Check out the [Installation Guide][doc/install] to install `git-bug`
+  - _Looking for the [latest release][rel/latest]?_
+- Take a look at the [User Guide][doc/user-guide] for usage instructions
+- Read the [Engineering Documentation][doc/contrib] and contribute if
+  inspiration strikes! We welcome all programmers, new and experienced alike
+- Start a [new discussion][discuss/new] or [browse existing ones][discuss] to
+  ask a question or see what the community is focused on
+- Join us [on Matrix][matrix/url] for ongoing, asynchronous chat
 
 ## Workflows
 
@@ -110,7 +62,9 @@ There are multiple ways to use `git-bug`:
     <img src="misc/diagrams/native_workflow.png" alt="Native workflow">
 </p>
 
-This is the pure `git-bug` experience. In a similar fashion as with code, use `git bug push` and `git bug pull` to push and pull your bugs between git remotes and collaborate with your teammate.
+This is the pure `git-bug` experience. In a similar fashion as with code, use
+`git bug push` and `git bug pull` to push and pull your bugs between git remotes
+and collaborate with your teammate.
 
 </details>
 
@@ -119,7 +73,10 @@ This is the pure `git-bug` experience. In a similar fashion as with code, use `g
     <img src="misc/diagrams/bridge_workflow.png" alt="Bridge workflow">
 </p>
 
-As `git-bug` has bridges with other bug-trackers, you can use it as your personal local remote interface. Sync with `git bug bridge pull` and `git bug bridge push`, work from your terminal, integrate into your editor, it's up to you. And it works offline !
+As `git-bug` has bridges with other bug-trackers, you can use it as your
+personal local remote interface. Sync with `git bug bridge pull` and `git bug
+bridge push`, work from your terminal, integrate into your editor, it's up to
+you. And it works offline !
 
 </details>
 
@@ -128,7 +85,10 @@ As `git-bug` has bridges with other bug-trackers, you can use it as your persona
     <img src="misc/diagrams/webui-workflow.png" alt="Web UI workflow">
 </p>
 
-Often, projects needs to have their bug-tracker public and accept editions from anyone facing a problem. To support this workflow, `git-bug` aims to have the web UI accept external OAuth authentication and act as a public portal. However the web UI is not up to speed for that yet. Contribution are very much welcome!
+Often, projects needs to have their bug-tracker public and accept editions from
+anyone facing a problem. To support this workflow, `git-bug` aims to have the
+web UI accept external OAuth authentication and act as a public portal. However
+the web UI is not up to speed for that yet. Contribution are very much welcome!
 
 </details>
 
@@ -149,78 +109,98 @@ git bug add
 Your favorite editor will open to write a title and a message.
 
 You can push your new entry to a remote:
+
 ```
 git bug push [<remote>]
 ```
 
 And pull for updates:
+
 ```
 git bug pull [<remote>]
 ```
 
 List existing bugs:
+
 ```
 git bug ls
 ```
 
 Filter and sort bugs using a [query](doc/queries.md):
+
 ```
 git bug ls "status:open sort:edit"
 ```
 
 Search for bugs by text content:
+
 ```
 git bug ls "foo bar" baz
 ```
 
-You can now use commands like `show`, `comment`, `open` or `close` to display and modify bugs. For more details about each command, you can run `git bug <command> --help` or read the [command's documentation](doc/md/git-bug.md).
+You can now use commands like `show`, `comment`, `open` or `close` to display
+and modify bugs. For more details about each command, you can run `git bug
+<command> --help` or read the [command's documentation](doc/md/git-bug.md).
 
-## Interactive terminal UI
+## Interactive TUI (terminal UI)
 
-An interactive terminal UI is available using the command `git bug termui` to browse and edit bugs.
+An interactive TUI (terminal UI) is available using the command `git bug termui` to
+browse and edit bugs.
 
 ![Termui recording](misc/termui_recording.gif)
 
+[api/gql/schema]: ./api/graphql/schema
+
 ## Web UI
 
-You can launch a rich Web UI with `git bug webui`.
+You can launch a Web UI with `git bug webui`:
 
+<details><summary>View a feed of bugs</summary>
 <p align="center">
   <img src="misc/webui1.png" alt="Web UI screenshot 1" width="880">
 </p>
+</details>
 
+<details><summary>View comments on bug</summary>
 <p align="center">
   <img src="misc/webui2.png" alt="Web UI screenshot 2" width="880">
 </p>
+</details>
 
-This web UI is entirely packed inside the same go binary and serve static content through a localhost http server.
+This web UI is packed inside the same binary and serves static
+content through an http server running on the local host machine.
 
-The web UI interact with the backend through a GraphQL API. The schema is available [here](api/graphql/schema).
+The web UI interacts with the backend through a GraphQL API. [View the
+schema][api/gql/schema] for more information.
 
-## Bridges
+## <a name="bridges"></a> Bridge compatibility
 
-✅: working  🟠: partial implementation  ❌: not working
+> [!NOTE]
+> Legend for the tables below:
+> - :white_check_mark: _implemented_
+> - :large_orange_diamond: _partial implementation_
+> - :x: _not yet implemented_
 
 ### Importer implementations
 
-|                                                 | Github | Gitlab | Jira | Launchpad |
-|-------------------------------------------------|:------:|:------:|:----:|:---------:|
-| **incremental**<br/>(can import more than once) |   ✅    |   ✅    |  ✅   |     ❌     |
-| **with resume**<br/>(download only new data)    |   ✅    |   ✅    |  ✅   |     ❌     |
-| **identities**                                  |   🟠   |   🟠   |  🟠  |    🟠     |
-| **bugs**                                        |   ✅    |   ✅    |  ✅   |    🟠     |
-| **board**                                       |   ❌    |   ❌    |  ❌   |     ❌     |
-| **media/files**                                 |   ❌    |   ❌    |  ❌   |     ❌     |
-| **automated test suite**                        |   ✅    |   ✅    |  ❌   |     ❌     |
+|                          | Github                 | Gitlab                 | Jira                   | Launchpad              |
+| ------------------------ | ---------------------- | ---------------------- | ---------------------- | ---------------------- |
+| **incremental**          | :white_check_mark:     | :white_check_mark:     | :white_check_mark:     | :x:                    |
+| **with resume**          | :white_check_mark:     | :white_check_mark:     | :white_check_mark:     | :x:                    |
+| **identities**           | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: |
+| **bugs**                 | :white_check_mark:     | :white_check_mark:     | :white_check_mark:     | :large_orange_diamond: |
+| **board**                | :x:                    | :x:                    | :x:                    | :x:                    |
+| **media/files**          | :x:                    | :x:                    | :x:                    | :x:                    |
+| **automated test suite** | :white_check_mark:     | :white_check_mark:     | :x:                    | :x:                    |
 
 ### Exporter implementations
 
-|                          | Github | Gitlab | Jira | Launchpad |
-|--------------------------|:------:|:------:|:----:|:---------:|
-| **identities**           |   🟠   |   🟠   |  🟠  |    🟠     |
-| **bug**                  |   ✅    |   ✅    |  ✅   |     ❌     |
-| **board**                |   ❌    |   ❌    |  ❌   |     ❌     |
-| **automated test suite** |   ✅    |   ✅    |  ❌   |     ❌     |
+|                          | Github                 | Gitlab                 | Jira                   | Launchpad              |
+| ------------------------ | ---------------------- | ---------------------- | ---------------------- | ---------------------- |
+| **identities**           | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: |
+| **bug**                  | :white_check_mark:     | :white_check_mark:     | :white_check_mark:     | :x:                    |
+| **board**                | :x:                    | :x:                    | :x:                    | :x:                    |
+| **automated test suite** | :white_check_mark:     | :white_check_mark:     | :x:                    | :x:                    |
 
 #### Bridge usage
 
@@ -261,34 +241,41 @@ git bug bridge rm [<name>]
 
 ## Internals
 
-Interested in how it works ? Have a look at the [data model](doc/model.md) and the [internal bird-view](doc/architecture.md).
+Interested in how it works? Take a look at the [data model](doc/model.md) and
+the [internal architecture](doc/architecture.md).
 
-Or maybe you want to [make your own distributed data-structure in git](entity/dag/example_test.go) ?
+Or maybe you want to build your own [distributed data-structure in
+git](entity/dag/example_test.go)?
 
-See also all the [docs](doc).
+[Read the documentation](doc) for more information.
 
 ## Misc
 
-- [Bash, Zsh, fish, powershell completion](misc/completion)
-- [ManPages](doc/man)
+- [Shell completion](misc/completion) for Bash, Zsh, Fish, and Powershell
+- View the raw [manpages](doc/man), or `man git-bug`
 
 ## Planned features
 
-The [feature matrix](doc/feature_matrix.md) gives a good overview of what is planned, without being exhaustive.
+The [feature matrix](doc/feature_matrix.md) gives a good overview of what is
+planned, without being exhaustive.
 
 Additional planned feature:
+
 - webUI that can be used as a public portal to accept user's input
 - inflatable raptor
 
 ## Contribute
 
-PRs accepted. Drop by the [Gitter lobby](https://gitter.im/the-git-bug/Lobby) or the [Matrix room](https://matrix.to/#/#the-git-bug_Lobby:gitter.im) for a chat, look at the [feature matrix](doc/feature_matrix.md) or browse the issues to see what is worked on or discussed.
+We welcome PRs! Drop by [Matrix][matrix/url] or for a chat, look at the [feature
+matrix](doc/feature_matrix.md) or browse the issues to see what is being worked
+on or discussed.
 
 ```shell
 git clone git@github.com:git-bug/git-bug.git
 ```
 
-You can now run `make` to build the project, or `make install` to install the binary in `$GOPATH/bin/`.
+You can now run `make` to build the project, or `make install` to install the
+binary in `$GOPATH/bin/`.
 
 To work on the web UI, have a look at [the dedicated Readme.](webui/Readme.md)
 
@@ -300,37 +287,91 @@ changed, run the following command, then inspect the changed files in
 go test ./commands -update
 ```
 
-## Contributors :heart:
+## <a name="contributors"></a> Contributors :computer:
 
-This project exists thanks to all the people who contribute.
-<a href="https://github.com/git-bug/git-bug/graphs/contributors"><img src="https://opencollective.com/git-bug/contributors.svg?width=890&button=false" /></a>
+This project exists thanks to all of the engineering talent that has contributed
+to it over the years. We couldn't do it [without your help][contributors/url]!
 
+[![Contributors][contributors]][contributors/url]
 
-## Backers
+## <a name="backers"></a> Backers :star:
 
-Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/git-bug#backer)]
+Thank you to all of our backers! :tada: [Want your picture to show up here?][oc/backers/url]
 
-<a href="https://opencollective.com/git-bug#backers" target="_blank"><img src="https://opencollective.com/git-bug/tiers/backer.svg?width=890"></a>
+<center>
 
+[![Backers][oc/backers]][oc/backers/url]
 
-## Sponsors
+</center>
 
-Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/git-bug#sponsor)]
+## <a name="sponsors"></a> Sponsors :star2:
 
-<a href="https://opencollective.com/git-bug/sponsor/0/website" target="_blank"><img src="https://opencollective.com/git-bug/tiers/sponsor/0/avatar.svg"></a>
-<a href="https://opencollective.com/git-bug/sponsor/1/website" target="_blank"><img src="https://opencollective.com/git-bug/tiers/sponsor/1/avatar.svg"></a>
-<a href="https://opencollective.com/git-bug/sponsor/2/website" target="_blank"><img src="https://opencollective.com/git-bug/tiers/sponsor/2/avatar.svg"></a>
-<a href="https://opencollective.com/git-bug/sponsor/3/website" target="_blank"><img src="https://opencollective.com/git-bug/tiers/sponsor/3/avatar.svg"></a>
-<a href="https://opencollective.com/git-bug/sponsor/4/website" target="_blank"><img src="https://opencollective.com/git-bug/tiers/sponsor/4/avatar.svg"></a>
-<a href="https://opencollective.com/git-bug/sponsor/5/website" target="_blank"><img src="https://opencollective.com/git-bug/tiers/sponsor/5/avatar.svg"></a>
-<a href="https://opencollective.com/git-bug/sponsor/6/website" target="_blank"><img src="https://opencollective.com/git-bug/tiers/sponsor/6/avatar.svg"></a>
-<a href="https://opencollective.com/git-bug/sponsor/7/website" target="_blank"><img src="https://opencollective.com/git-bug/tiers/sponsor/7/avatar.svg"></a>
-<a href="https://opencollective.com/git-bug/sponsor/8/website" target="_blank"><img src="https://opencollective.com/git-bug/tiers/sponsor/8/avatar.svg"></a>
-<a href="https://opencollective.com/git-bug/sponsor/9/website" target="_blank"><img src="https://opencollective.com/git-bug/tiers/sponsor/9/avatar.svg"></a>
+Support this project by becoming a sponsor. Your logo will show up here with a
+link to your website. [Become a sponsor today!][oc/sponsors/url]
 
+<center>
+
+[![OC Sponsor 0][oc/sponsor/0]][oc/sponsor/0/url]
+[![OC Sponsor 1][oc/sponsor/1]][oc/sponsor/1/url]
+[![OC Sponsor 2][oc/sponsor/2]][oc/sponsor/2/url]
+[![OC Sponsor 3][oc/sponsor/3]][oc/sponsor/3/url]
+[![OC Sponsor 4][oc/sponsor/4]][oc/sponsor/4/url]
+[![OC Sponsor 5][oc/sponsor/5]][oc/sponsor/5/url]
+[![OC Sponsor 6][oc/sponsor/6]][oc/sponsor/6/url]
+[![OC Sponsor 7][oc/sponsor/7]][oc/sponsor/7/url]
+[![OC Sponsor 8][oc/sponsor/8]][oc/sponsor/8/url]
+[![OC Sponsor 9][oc/sponsor/9]][oc/sponsor/9/url]
+
+<center>
 
 ## License
 
-Unless otherwise stated, this project is released under the [GPLv3](LICENSE) or later license © Michael Muré.
+Unless otherwise stated, this project and all assets within it are released
+under the [GPLv3][license/url] or later license &copy; Michael Muré.
 
-The git-bug logo by [Viktor Teplov](https://github.com/vandesign) is released under the [Creative Commons Attribution 4.0 International (CC BY 4.0)](misc/logo/LICENSE) license © Viktor Teplov.
+The `git-bug` logo is authored by [Viktor Teplov](https://github.com/vandesign)
+and is released under the [Creative Commons Attribution 4.0 International (CC BY
+4.0)](misc/logo/LICENSE) license &copy; Viktor Teplov.
+
+[ci/badge]: https://github.com/MichaelMure/git-bug/actions/workflows/trunk.yml/badge.svg
+[ci/url]: https://github.com/MichaelMure/git-bug/actions/workflows/trunk.yml
+[doc/install]: INSTALLATION.md
+[doc/contrib]: CONTRIBUTING.md
+[doc/user-guide]: doc/user-guide/README.md
+[contributors/url]: https://github.com/MichaelMure/git-bug/graphs/contributors
+[contributors]: https://opencollective.com/git-bug/contributors.svg?avatarHeight=40&width=890&button=false
+[godoc/badge]: https://godoc.org/github.com/MichaelMure/git-bug?status.svg
+[godoc/url]: https://godoc.org/github.com/MichaelMure/git-bug
+[license/badge]: https://img.shields.io/badge/License-GPLv3+-blue.svg
+[license/url]: https://github.com/MichaelMure/git-bug/blob/master/LICENSE
+[matrix/badge]: https://img.shields.io/badge/chat%20on%20matrix-%23238636
+[matrix/url]: https://matrix.to/#/#git-bug:matrix.org
+[mm]: https://github.com/MichaelMure
+[oc/backers/badge]: https://opencollective.com/git-bug/backers/badge.svg
+[oc/backers/url]: https://opencollective.com/git-bug#backers
+[oc/backers]: https://opencollective.com/shields/backers.svg?avatarHeight=40&width=890&button=false
+[oc/sponsor/0/url]: https://opencollective.com/git-bug/sponsor/0/website
+[oc/sponsor/0]: https://opencollective.com/git-bug/tiers/sponsor/0/avatar.svg
+[oc/sponsor/1/url]: https://opencollective.com/git-bug/sponsor/1/website
+[oc/sponsor/1]: https://opencollective.com/git-bug/tiers/sponsor/1/avatar.svg
+[oc/sponsor/2/url]: https://opencollective.com/git-bug/sponsor/2/website
+[oc/sponsor/2]: https://opencollective.com/git-bug/tiers/sponsor/2/avatar.svg
+[oc/sponsor/3/url]: https://opencollective.com/git-bug/sponsor/3/website
+[oc/sponsor/3]: https://opencollective.com/git-bug/tiers/sponsor/3/avatar.svg
+[oc/sponsor/4/url]: https://opencollective.com/git-bug/sponsor/4/website
+[oc/sponsor/4]: https://opencollective.com/git-bug/tiers/sponsor/4/avatar.svg
+[oc/sponsor/5/url]: https://opencollective.com/git-bug/sponsor/5/website
+[oc/sponsor/5]: https://opencollective.com/git-bug/tiers/sponsor/5/avatar.svg
+[oc/sponsor/6/url]: https://opencollective.com/git-bug/sponsor/6/website
+[oc/sponsor/6]: https://opencollective.com/git-bug/tiers/sponsor/6/avatar.svg
+[oc/sponsor/7/url]: https://opencollective.com/git-bug/sponsor/7/website
+[oc/sponsor/7]: https://opencollective.com/git-bug/tiers/sponsor/7/avatar.svg
+[oc/sponsor/8/url]: https://opencollective.com/git-bug/sponsor/8/website
+[oc/sponsor/8]: https://opencollective.com/git-bug/tiers/sponsor/8/avatar.svg
+[oc/sponsor/9/url]: https://opencollective.com/git-bug/sponsor/9/website
+[oc/sponsor/9]: https://opencollective.com/git-bug/tiers/sponsor/9/avatar.svg
+[oc/sponsors/badge]: https://opencollective.com/git-bug/sponsors/badge.svg
+[oc/sponsors/url]: https://opencollective.com/git-bug#sponsor
+[rel/latest]: https://github.com/MichaelMure/git-bug/releases/latest
+[report-card/badge]: https://goreportcard.com/badge/github.com/MichaelMure/git-bug
+[report-card/url]: https://goreportcard.com/report/github.com/MichaelMure/git-bug


### PR DESCRIPTION
This is a temporary change in this tree, so that the relevant pipelines
do not run for each commit. It should not be committed to trunk.

Change-Id: I570470e8d81c4bb8827086e332602042c618e5fa