### PR TITLE
refactor: rename github test repository: test-github-bridge

### DIFF
--- a/bridge/github/config_test.go
+++ b/bridge/github/config_test.go
@@ -191,7 +191,7 @@ func TestValidateProject(t *testing.T) {
 		{
 			name: "private repository and token with scope 'repo'",
 			args: args{
-				project: "git-bug-test-github-bridge",
+				project: "test-github-bridge",
 				owner:   "git-bug",
 				token:   tokenPrivate,
 			},
@@ -200,7 +200,7 @@ func TestValidateProject(t *testing.T) {
 		{
 			name: "private repository and token with scope 'public_repo'",
 			args: args{
-				project: "git-bug-test-github-bridge",
+				project: "test-github-bridge",
 				owner:   "git-bug",
 				token:   tokenPublic,
 			},

--- a/bridge/github/import_test.go
+++ b/bridge/github/import_test.go
@@ -48,7 +48,7 @@ func TestGithubImporter(t *testing.T) {
 	}{
 		{
 			name: "simple issue",
-			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/1",
+			url:  "https://github.com/git-bug/test-github-bridge/issues/1",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "simple issue", "initial comment", nil),
@@ -59,7 +59,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "empty issue",
-			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/2",
+			url:  "https://github.com/git-bug/test-github-bridge/issues/2",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "empty issue", "", nil),
@@ -68,7 +68,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "complex issue",
-			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/3",
+			url:  "https://github.com/git-bug/test-github-bridge/issues/3",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "complex issue", "initial comment", nil),
@@ -112,7 +112,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "editions",
-			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/4",
+			url:  "https://github.com/git-bug/test-github-bridge/issues/4",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "editions", "initial comment edited", nil),
@@ -124,7 +124,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "comment deletion",
-			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/5",
+			url:  "https://github.com/git-bug/test-github-bridge/issues/5",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "comment deletion", "", nil),
@@ -133,7 +133,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "edition deletion",
-			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/6",
+			url:  "https://github.com/git-bug/test-github-bridge/issues/6",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "edition deletion", "initial comment", nil),
@@ -145,7 +145,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "hidden comment",
-			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/7",
+			url:  "https://github.com/git-bug/test-github-bridge/issues/7",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "hidden comment", "initial comment", nil),
@@ -155,7 +155,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "transferred issue",
-			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/8",
+			url:  "https://github.com/git-bug/test-github-bridge/issues/8",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "transfered issue", "", nil),
@@ -164,7 +164,7 @@ func TestGithubImporter(t *testing.T) {
 		},
 		{
 			name: "unicode control characters",
-			url:  "https://github.com/git-bug/git-bug-test-github-bridge/issues/10",
+			url:  "https://github.com/git-bug/test-github-bridge/issues/10",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "unicode control characters", "u0000: \nu0001: \nu0002: \nu0003: \nu0004: \nu0005: \nu0006: \nu0007: \nu0008: \nu0009: \t\nu0010: \nu0011: \nu0012: \nu0013: \nu0014: \nu0015: \nu0016: \nu0017: \nu0018: \nu0019:", nil),
@@ -186,7 +186,7 @@ func TestGithubImporter(t *testing.T) {
 	importer := &githubImporter{}
 	err = importer.Init(ctx, backend, core.Configuration{
 		confKeyOwner:        "git-bug",
-		confKeyProject:      "git-bug-test-github-bridge",
+		confKeyProject:      "test-github-bridge",
 		confKeyDefaultLogin: login,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
This change renames references to the repository used to test the github
bridge from `git-bug-test-github-bridge` to `test-github-bridge`,
dropping the `git-bug` prefix as it is extraneous now that it is under
the `git-bug` organization.

Change-Id: I5795bd39cc3b2e81774c4d9676ae5cbabfba8f1c