### PR TITLE
Update README.md Matrix link to new room

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Additional planned feature:
 
 ## Contribute
 
-PRs accepted. Drop by the [Gitter lobby](https://gitter.im/the-git-bug/Lobby) or the [Matrix room](https://matrix.to/#/#the-git-bug_Lobby:gitter.im) for a chat, look at the [feature matrix](doc/feature_matrix.md) or browse the issues to see what is worked on or discussed.
+PRs accepted. Drop by the [Gitter lobby](https://gitter.im/the-git-bug/Lobby) or the [Matrix room](https://matrix.to/#/#git-bug:matrix.org) for a chat, look at the [feature matrix](doc/feature_matrix.md) or browse the issues to see what is worked on or discussed.
 
 ```shell
 git clone git@github.com:git-bug/git-bug.git


### PR DESCRIPTION
The old room has a message from ﻿sudoforge saying

> 👋 hi there! this is just a friendly message noting that the source of truth for the community is moving off of gitter's server, onto the matrix foundation's public server. the address for that room is: 
[git-bug](https://matrix.to/#/#git-bug:matrix.org)

And the new room has:

> 👋 hey folks. this [matrix.org](http://matrix.org/) room is going to become the source of truth for the git-bug community. let me know if you have any questions!