### PR TITLE
docs: use `configure` instead of `new` for  bridges in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,17 +227,17 @@ The web UI interact with the backend through a GraphQL API. The schema is availa
 Interactively configure a new github bridge:
 
 ```bash
-git bug bridge new
+git bug bridge configure
 ```
 
 Or manually:
 
 ```bash
-git bug bridge new \
+git bug bridge configure \
     --name=<bridge> \
     --target=github \
-    --url=https://github.com/git-bug/git-bug \
-    --login=<login> \
+    --owner=git-bug \
+    --project=git-bug \
     --token=<token>
 ```
 


### PR DESCRIPTION
It seems that the command to set up a bridge has changed and the readme hasn't been updated. This is very confusing, so I hope you can accept this small PR.