### PR TITLE
revert: "Create Dependabot config file"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10


### PR DESCRIPTION
This reverts commit cc3b7c328dd4e4ad51de15919962d62f1146ca51,
effectively disabling Dependabot. This is being done primarily due to
git-bug/git-bug#1367, but also because the implementation of this bot is
noisy and often broken (failing to run `go mod tidy`, resulting in a CI
error that requires manual intervention to fix).

Automatically updating dependencies is helpful, but not a priority right
now. In the future, it is possible to revert this commit, however, I
would suggest looking at renovate [0] as an alternative approach, as I
personally find it to be far less invasive/noisy (see #1247).

[0]: https://docs.renovatebot.com/

Change-Id: I32f06381e1abf66a2655b5b6ba5c96cca6124720