### PR TITLE
fix: use -0700 when formatting time

### DIFF
--- a/commands/user/user_show.go
+++ b/commands/user/user_show.go
@@ -69,7 +69,7 @@ func runUserShow(env *execenv.Env, opts userShowOptions, args []string) error {
 			env.Out.Printf("%s\n", id.Id())
 		case "lastModification":
 			env.Out.Printf("%s\n", id.LastModification().
-				Time().Format("Mon Jan 2 15:04:05 2006 +0200"))
+				Time().Format("Mon Jan 2 15:04:05 2006 -0700"))
 		case "lastModificationLamport":
 			for name, t := range id.LastModificationLamports() {
 				env.Out.Printf("%s\n%d\n", name, t)
@@ -92,7 +92,7 @@ func runUserShow(env *execenv.Env, opts userShowOptions, args []string) error {
 	env.Out.Printf("Name: %s\n", id.Name())
 	env.Out.Printf("Email: %s\n", id.Email())
 	env.Out.Printf("Login: %s\n", id.Login())
-	env.Out.Printf("Last modification: %s\n", id.LastModification().Time().Format("Mon Jan 2 15:04:05 2006 +0200"))
+	env.Out.Printf("Last modification: %s\n", id.LastModification().Time().Format("Mon Jan 2 15:04:05 2006 -0700"))
 	env.Out.Printf("Last moditication (lamport):\n")
 	for name, t := range id.LastModificationLamports() {
 		env.Out.Printf("\t%s: %d", name, t)

--- a/entities/bug/comment.go
+++ b/entities/bug/comment.go
@@ -45,7 +45,7 @@ func (c Comment) FormatTimeRel() string {
 }
 
 func (c Comment) FormatTime() string {
-	return c.unixTime.Time().Format("Mon Jan 2 15:04:05 2006 +0200")
+	return c.unixTime.Time().Format("Mon Jan 2 15:04:05 2006 -0700")
 }
 
 // IsAuthored is a sign post method for gqlgen


### PR DESCRIPTION
+0200 is not a valid reference identifier for the time format string,
which requires a valid layout [0] using the reference time `01/02
03:04:05PM '06 -0700`.

As the documentation notes:
> It is a regrettable historic error that the date uses the American
> convention of putting the numerical month before the day.

This, combined with `-0700` being hardcoded into the layout requirements
is what likely led to the confusion that caused this issue. This change
is a fix for all `Time.Format()` calls, adjusting the time format in
place to use the correct tzdata. As a future potential improvement, we
should consider refactoring the format to use one of the constants in
the time package that are exported for the different predefined
formatting strings. This is not being done as part of this change
because the current formatting string used in these calls does not match
exactly with any of the predefined format strings.

... it isn't clear to me why this passes on CI. Using `+0200` to
reference the timezone in the format string is invalid according to the
`time` package documentation.

[0]: https://pkg.go.dev/time#Layout

Closes: #1387
Change-Id: Ifa198266c407524f7ef33ee33cf94ce9d0158f45