### PR TITLE
test: simplify github-related variables

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Test
         run: make test
         env:
-          GITHUB_TEST_USER: ${{ secrets._GITHUB_TEST_USER }}
-          GITHUB_TOKEN_ADMIN: ${{ secrets._GITHUB_TOKEN_ADMIN }}
+          GITHUB_USER: ${{ env.TEST_USER_GITHUB }}
+          GITHUB_TOKEN: ${{ secrets.TEST_TOKEN_GITHUB }}
           GITHUB_TOKEN_PRIVATE: ${{ secrets._GITHUB_TOKEN_PRIVATE }}
           GITHUB_TOKEN_PUBLIC: ${{ secrets._GITHUB_TOKEN_PUBLIC }}
           GITLAB_API_TOKEN: ${{ secrets.GITLAB_API_TOKEN }}

--- a/bridge/github/export_test.go
+++ b/bridge/github/export_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"net/http"
 	"os"
@@ -130,12 +131,15 @@ func testCases(t *testing.T, repo *cache.RepoCache) []*testCase {
 
 func TestGithubPushPull(t *testing.T) {
 	// repo owner
-	envUser := os.Getenv("GITHUB_TEST_USER")
+	envUser := os.Getenv("GITHUB_USER")
+	if envUser == "" {
+		t.Skip("missing required environment variable: GITHUB_USER")
+	}
 
 	// token must have 'repo' and 'delete_repo' scopes
-	envToken := os.Getenv("GITHUB_TOKEN_ADMIN")
+	envToken := os.Getenv("GITHUB_TOKEN")
 	if envToken == "" {
-		t.Skip("Env var GITHUB_TOKEN_ADMIN missing")
+		t.Skip("missing required environment variable: GITHUB_TOKEN")
 	}
 
 	// create repo backend
@@ -179,7 +183,7 @@ func TestGithubPushPull(t *testing.T) {
 	err = createRepository(projectName, envToken)
 	require.NoError(t, err)
 
-	fmt.Println("created repository", projectName)
+	slog.Info("created github repository", "name", projectName)
 
 	// Let Github handle the repo creation and update all their internal caches.
 	// Avoid HTTP error 404 retrieving repository node id

--- a/bridge/github/import_test.go
+++ b/bridge/github/import_test.go
@@ -22,9 +22,9 @@ import (
 )
 
 func TestGithubImporter(t *testing.T) {
-	envToken := os.Getenv("GITHUB_TOKEN_PRIVATE")
+	envToken := os.Getenv("GITHUB_TOKEN")
 	if envToken == "" {
-		t.Skip("Env var GITHUB_TOKEN_PRIVATE missing")
+		t.Skip("missing required environment variable: GITHUB_TOKEN")
 	}
 
 	repo := repository.CreateGoGitTestRepo(t, false)


### PR DESCRIPTION
This change removes extraneous variables used for the github bridge
(e2e) tests, conslidating on GITHUB_USER and GITHUB_TOKEN, which match
the variables read by the github CLI and what users would have in their
environment if they are using the vars.

We leave GITHUB_TOKEN_PRIVATE and GITHUB_TOKEN_PUBLIC for now, as those
are used in a single test to validate a minimum set of permissions.
Moving away from these will require additional refactoring.

Change-Id: I8d83e4f0c9b2556133c5ec3daca492fe1a4bd968

