### PR TITLE
test: implement support for Failed() and FailedNow()

### DIFF
--- a/internal/test/recorder.go
+++ b/internal/test/recorder.go
@@ -5,24 +5,46 @@ import (
 	"testing"
 )
 
+const (
+	RecorderFailNow int = iota
+)
+
 type recorder struct {
 	testing.TB
-	fail  func(string)
-	fatal func(string)
-}
-
-func (r *recorder) Errorf(format string, args ...any) {
-	r.fail(fmt.Sprintf(format, args...))
-}
-
-func (r *recorder) Fatalf(format string, args ...any) {
-	r.fatal(fmt.Sprintf(format, args...))
-}
-
-func (r *recorder) Fatal(args ...any) {
-	r.fatal(fmt.Sprint(args...))
+	fail   func(string)
+	fatal  func(string)
+	failed bool
 }
 
 func (r *recorder) Error(args ...any) {
+	r.failed = true
 	r.fail(fmt.Sprint(args...))
+}
+
+func (r *recorder) Errorf(format string, args ...any) {
+	r.failed = true
+	r.fail(fmt.Sprintf(format, args...))
+}
+
+func (r *recorder) Fail() {
+	r.failed = true
+}
+
+func (r *recorder) FailNow() {
+	r.failed = true
+	panic(RecorderFailNow)
+}
+
+func (r *recorder) Failed() bool {
+	return r.failed
+}
+
+func (r *recorder) Fatal(args ...any) {
+	r.failed = true
+	r.fatal(fmt.Sprint(args...))
+}
+
+func (r *recorder) Fatalf(format string, args ...any) {
+	r.failed = true
+	r.fatal(fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
This change adds support to //internal/test for Failed() and
FailedNow(), and expands the support for setting and detecting the
failed status on //internal/test%recorder.

Change-Id: I04e7a978cbf0ead8d28722c0a3a0fc34136e72e1