### PR TITLE
test: add support for Helper()

### DIFF
--- a/internal/test/recorder.go
+++ b/internal/test/recorder.go
@@ -7,6 +7,8 @@ import (
 
 const (
 	RecorderFailNow int = iota
+	RecorderFatal
+	RecorderFatalf
 )
 
 type recorder struct {
@@ -17,20 +19,24 @@ type recorder struct {
 }
 
 func (r *recorder) Error(args ...any) {
+	r.Helper()
 	r.failed = true
 	r.fail(fmt.Sprint(args...))
 }
 
 func (r *recorder) Errorf(format string, args ...any) {
+	r.Helper()
 	r.failed = true
 	r.fail(fmt.Sprintf(format, args...))
 }
 
 func (r *recorder) Fail() {
+	r.Helper()
 	r.failed = true
 }
 
 func (r *recorder) FailNow() {
+	r.Helper()
 	r.failed = true
 	panic(RecorderFailNow)
 }
@@ -40,11 +46,19 @@ func (r *recorder) Failed() bool {
 }
 
 func (r *recorder) Fatal(args ...any) {
+	r.Helper()
 	r.failed = true
 	r.fatal(fmt.Sprint(args...))
+	panic(RecorderFatal)
 }
 
 func (r *recorder) Fatalf(format string, args ...any) {
+	r.Helper()
 	r.failed = true
 	r.fatal(fmt.Sprintf(format, args...))
+	panic(RecorderFatalf)
+}
+
+func (r *recorder) Helper() {
+	r.TB.Helper()
 }


### PR DESCRIPTION
This change adds support to //internal/test%recorder for Helper(), and
improves the ergonomics around error reporting.

Change-Id: Ia1762587b16dee9ba6ca3c428c1f935eb333a63b