### PR TITLE
fix: remove errata from string literal

### DIFF
--- a/misc/completion/bash/git-bug
+++ b/misc/completion/bash/git-bug
@@ -352,11 +352,11 @@ _git_bug() {
         __git-bug_init_completion -n "=:" || return
     fi
 
-	# START PATCH
-	# replace in the array ("git","bug", ...) to ("git-bug", ...) and adjust the index in cword 
+    # START PATCH
+    # replace in the array ("git","bug", ...) to ("git-bug", ...) and adjust the index in cword
     words=("git-bug" "${words[@]:2}")
     cword=$(($cword-1))
-	# END PATCH
+    # END PATCH
 
     __git-bug_debug
     __git-bug_debug "========= starting completion logic =========="

--- a/misc/completion/generate.go
+++ b/misc/completion/generate.go
@@ -66,11 +66,11 @@ _git_bug() {
         __git-bug_init_completion -n "=:" || return
     fi
 
-	# START PATCH
-	# replace in the array ("git","bug", ...) to ("git-bug", ...) and adjust the index in cword
+    # START PATCH
+    # replace in the array ("git","bug", ...) to ("git-bug", ...) and adjust the index in cword
     words=("git-bug" "${words[@]:2}")
     cword=$(($cword-1))
-	# END PATCH
+    # END PATCH
 
     __git-bug_debug
     __git-bug_debug "========= starting completion logic =========="


### PR DESCRIPTION
This change replaces tabs inside of a raw string literal used as a patch
for the shell completion files with spaces, and removes a trailing
space. This fixes an issue where regeneration of the file would lead to
a diff.

Change-Id: I3469a859ed63fe4ef9b8b6f156ff0ce5cb7af91c