### PR TITLE
test: use pkgs.runCommand for the pinact check drv

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -51,7 +51,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/nix/checks/pinact.nix
+++ b/nix/checks/pinact.nix
@@ -1,7 +1,12 @@
 { pkgs, src }:
 
-pkgs.writeShellApplication {
-  name = "pinact";
-  runtimeInputs = with pkgs; [ pinact ];
-  text = "pinact run --check --verify";
-}
+pkgs.runCommand "pinact"
+  {
+    inherit src;
+    nativeBuildInputs = with pkgs; [ pinact ];
+  }
+  ''
+    cd "$src"
+    pinact run --check --verify
+    touch "$out"
+  ''


### PR DESCRIPTION
This change refactors the derivation defined in //nix/checks:pinact.nix,
rewriting it with pkgs.runCommand so that `nix flake check` actually
executes it.

Change-Id: Ic941133bcbedd8505580db71abbaaaf8326fb874