### PR TITLE
feat(tui): improve readability of the help bar

### DIFF
--- a/termui/help_bar.go
+++ b/termui/help_bar.go
@@ -16,14 +16,19 @@ type helpBar []struct {
 
 func (hb helpBar) Render(maxX int) string {
 	var builder strings.Builder
-	for _, entry := range hb {
-		builder.WriteString(colors.White(colors.BlueBg(fmt.Sprintf("[%s] %s", entry.keys, entry.text))))
-		builder.WriteByte(' ')
+
+	il := len(hb) - 1
+	for i, entry := range hb {
+		builder.WriteString(colors.White(colors.BlackBg(fmt.Sprintf("[%s] %s", entry.keys, entry.text))))
+
+		if i < il {
+			builder.WriteString("  ")
+		}
 	}
 
-	l := text.Len(builder.String())
-	if l < maxX {
-		builder.WriteString(colors.White(colors.BlueBg(strings.Repeat(" ", maxX-l))))
+	tl := text.Len(builder.String())
+	if tl < maxX {
+		builder.WriteString(colors.White(colors.BlackBg(strings.Repeat(" ", maxX-tl))))
 	}
 
 	return builder.String()


### PR DESCRIPTION
This change changes the help bar's background color to the "black" value
for the terminal, and increases spacing between the different commands
to improve readability.

Closes: git-bug/git-bug#1411
Change-Id: I380d1fee4ae51869876f00c76c0f952d47dd8912