### PR TITLE
feat(dev-infra): add initial //:.mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,29 @@
+# This list is used by several git commands automatically, and several others
+# with a flag (or configuration option). It is used to fix a few botched names
+# in the archive, either because the author's name was messed up, misconfigured,
+# or not always written the same way, making contributions from the same person
+# appear to be from different people.
+#
+# See the documentation for gitmailmap (5) for more information:
+#    https://git-scm.com/docs/gitmailmap
+#
+# Names should be added to this file in alphabetical order unless the
+# alphabetical order for the rules you are setting up would cause undesired
+# results. In that event, create a newline after the last line in this file, add
+# an optional comment describing why you need to set up a custom order of rules,
+# and add your remapping rules in their own block. If you are not adding the
+# first custom block, add your block to the existing list of blocks in
+# alphabetical order.
+
+Amine Hilaly <hilalyamine@gmail.com>
+Cláudio Silva <claudio.engdist@gmail.com>
+Dmitry Teplov <siht.pilf@gmail.com> <teplov.work@gmail.com>
+Michael Muré <batolettre@gmail.com> <michael.mure@consensys.net>
+Robin Vobruba <hoijui.quaero@gmail.com>
+
+# This doesn't require special ordering, but it's a bot user. GitHub really
+# likes changing the identity, apparently.
+dependabot[bot] <support@dependabot.com> <27856297+dependabot-preview[bot]@users.noreply.github.com>
+dependabot[bot] <support@dependabot.com> <49699333+dependabot[bot]@users.noreply.github.com>
+dependabot[bot] <support@dependabot.com> <dependabot-preview[bot]@users.noreply.github.com>
+dependabot[bot] <support@dependabot.com> <dependabot[bot]@users.noreply.github.com>


### PR DESCRIPTION
This change adds //.mailmap initialized with mappings for duplicate
names and email addresses found in the repository archive. When a
duplicate was found, the name and email were chosen preferring the
longest name for the author, and the most practical email address (e.g.
if an obvious personal and professional email address existed, the
personal address was chosen).

Duplicate names were found with the following command:

    git shortlog -se |\
        awk 'match($0, /[0-9]+[ \t]+(.*)[ \t]+<.*>/, m) { print m[1] }' |\
        sort |\
        uniq -d

Duplicate email addresses were found with the following command:

    git shortlog -se |\
        awk 'match($0, /<[^>]+>/) { print substr($0, RSTART+1, RLENGTH-2) }' |\
        sort |\
        uniq -d

Change-Id: Ie0280ee336098c080cf5af8062dae20cb7a41e8e