### PR TITLE
fix(dev-infra): re-enable markdown formatting

### DIFF
--- a/treefmt.nix
+++ b/treefmt.nix
@@ -12,7 +12,7 @@
     };
 
     mdformat = {
-      enable = false;
+      enable = true;
 
       package = pkgs.mdformat.withPlugins (
         p: with p; [

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,15 +1,21 @@
 # git-bug rich web UI
 
 ## Prerequisites
-[ReactJS](https://reactjs.org/) | [Material UI](https://material-ui.com/) | [GraphQL](https://graphql.org/) | [Apollo GraphQL](https://www.apollographql.com/docs/react/)
+
+[ReactJS](https://reactjs.org/) | [Material UI](https://material-ui.com/) |
+[GraphQL](https://graphql.org/) |
+[Apollo GraphQL](https://www.apollographql.com/docs/react/)
 
 ## How to develop
 
 ### Run GraphQL backend
 
-1. Download a git-bug stable binary or compile your own by running `make` in the **root** directory:
+1. Download a git-bug stable binary or compile your own by running `make` in the
+   **root** directory:
 
-2. Run the git-bug binary inside your git repository. It will manage issues and start the API:
+2. Run the git-bug binary inside your git repository. It will manage issues and
+   start the API:
+
    - `git-bug webui -p 3001`
 
 ### Run ReactJS front-end
@@ -17,19 +23,25 @@
 1. If you haven't already, clone the git-bug repository:
 
 2. Enter the `webui` directory and install the needed libraries:
+
    - `make install` or `npm install`
 
-3. Generate the TS code from the GrapQL files and run the webui in development mode:
+3. Generate the TS code from the GrapQL files and run the webui in development
+   mode:
+
    - `make start` or `npm start`
    - If you get some lint errors, run the lint command below and start again:
-      - `make fix-lint` or `npm run lint -- --fix`
-      - `make start` or `npm start`
+     - `make fix-lint` or `npm run lint -- --fix`
+     - `make start` or `npm start`
 
-The development version of the WebUI is configured to query the backend on the port 3001. You can now live edit the js code and use the normal backend.
+The development version of the WebUI is configured to query the backend on the
+port 3001. You can now live edit the js code and use the normal backend.
 
 ## Bundle the web UI
 
 Once the webUI is good enough for a new release:
+
 1. run `make build` from webui folder
-2. run `make pack-webui` from the *root directory* to bundle the compiled js into the go binary.
+2. run `make pack-webui` from the *root directory* to bundle the compiled js
+   into the go binary.
    - You must have Go installed on Your machine to run this command.


### PR DESCRIPTION
This was disabled while debugging prettier vs. mdformat interactions
through treefmt, and accidentally committed in
08ffc2b82919b9254cc59c97756c546a508b4f73.

Change-Id: I14ebc1d0edf6ed755ad15b6ba58b6d9c6f5519f5