### PR TITLE
ci: limit default permissions to contents.read

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     uses: ./.github/workflows/build-and-test.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     uses: ./.github/workflows/build-and-test.yml


### PR DESCRIPTION
This change refactors all root pipelines (`trunk` and `presubmit`) to
limit the contents permission to read. By default, GitHub has taken the
overly-permissive approach of granting all permissions if the
`permissions` map is not explicitly defined. Usability wins out over
security, again.

Change-Id: Idaca851385fb82eefd6c7c9b8ee46b85a3f4901c