### PR TITLE
build(web): upgrade graphql-eslint plugin

### DIFF
--- a/webui/.eslintrc.js
+++ b/webui/.eslintrc.js
@@ -44,7 +44,7 @@ module.exports = {
         graphQLConfig: {
           schema: './src/schema.json',
           documents: './src/**/*.graphql',
-        }
+        },
       },
     },
   ],

--- a/webui/.eslintrc.js
+++ b/webui/.eslintrc.js
@@ -41,8 +41,10 @@ module.exports = {
         '@graphql-eslint/known-type-names': 'error',
       },
       parserOptions: {
-        schema: './src/schema.json',
-        operations: './src/**/*.graphql',
+        graphQLConfig: {
+          schema: './src/schema.json',
+          documents: './src/**/*.graphql',
+        }
       },
     },
   ],

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -43,7 +43,7 @@
         "@graphql-codegen/typescript": "^4.1.6",
         "@graphql-codegen/typescript-operations": "^4.6.1",
         "@graphql-codegen/typescript-react-apollo": "^4.3.2",
-        "@graphql-eslint/eslint-plugin": "^3.20.1",
+        "@graphql-eslint/eslint-plugin": "^4.4.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.15.18",
         "@types/react": "^19.1.4",
@@ -351,18 +351,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@ardatan/sync-fetch": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
-      "integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@arrows/composition": {
@@ -3048,344 +3036,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/batch-execute": {
-      "version": "9.0.15",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.15.tgz",
-      "integrity": "sha512-qlWUl6yi87FU5WvyJ0uD81R4Y30oQIuW3mJCjOrEvifyT+f/rEqSZFOhYrofYoZAoTcwqOhy6WgH+b9+AtRYjA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.8.1",
-        "@whatwg-node/promise-helpers": "^1.3.0",
-        "dataloader": "^2.2.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/batch-execute/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/code-file-loader": {
-      "version": "8.1.20",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.20.tgz",
-      "integrity": "sha512-GzIbjjWJIc04KWnEr8VKuPe0FA2vDTlkaeub5p4lLimljnJ6C0QSkOyCUnFmsB9jetQcHm0Wfmn/akMnFUG+wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/graphql-tag-pluck": "8.3.19",
-        "@graphql-tools/utils": "^10.8.6",
-        "globby": "^11.0.3",
-        "tslib": "^2.4.0",
-        "unixify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/delegate": {
-      "version": "10.2.17",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.2.17.tgz",
-      "integrity": "sha512-z+LpZrTQCEXA4fbdJcSsvhaMqT4xi/O8B0mP30ENGyTbSfa20QamOQx9jgCiw2ii/ucwxfGMhygwlpZG36EU4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/batch-execute": "^9.0.15",
-        "@graphql-tools/executor": "^1.4.7",
-        "@graphql-tools/schema": "^10.0.11",
-        "@graphql-tools/utils": "^10.8.1",
-        "@repeaterjs/repeater": "^3.0.6",
-        "@whatwg-node/promise-helpers": "^1.3.0",
-        "dataloader": "^2.2.3",
-        "dset": "^3.1.2",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/delegate/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/executor": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.4.7.tgz",
-      "integrity": "sha512-U0nK9jzJRP9/9Izf1+0Gggd6K6RNRsheFo1gC/VWzfnsr0qjcOSS9qTjY0OTC5iTPt4tQ+W5Zpw/uc7mebI6aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.8.6",
-        "@graphql-typed-document-node/core": "^3.2.0",
-        "@repeaterjs/repeater": "^3.0.4",
-        "@whatwg-node/disposablestack": "^0.0.6",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/executor-graphql-ws": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-2.0.5.tgz",
-      "integrity": "sha512-gI/D9VUzI1Jt1G28GYpvm5ckupgJ5O8mi5Y657UyuUozX34ErfVdZ81g6oVcKFQZ60LhCzk7jJeykK48gaLhDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/executor-common": "^0.0.4",
-        "@graphql-tools/utils": "^10.8.1",
-        "@whatwg-node/disposablestack": "^0.0.6",
-        "graphql-ws": "^6.0.3",
-        "isomorphic-ws": "^5.0.0",
-        "tslib": "^2.8.1",
-        "ws": "^8.17.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/executor-graphql-ws/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/executor-http": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.3.3.tgz",
-      "integrity": "sha512-LIy+l08/Ivl8f8sMiHW2ebyck59JzyzO/yF9SFS4NH6MJZUezA1xThUXCDIKhHiD56h/gPojbkpcFvM2CbNE7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-hive/signal": "^1.0.0",
-        "@graphql-tools/executor-common": "^0.0.4",
-        "@graphql-tools/utils": "^10.8.1",
-        "@repeaterjs/repeater": "^3.0.4",
-        "@whatwg-node/disposablestack": "^0.0.6",
-        "@whatwg-node/fetch": "^0.10.4",
-        "@whatwg-node/promise-helpers": "^1.3.0",
-        "meros": "^1.2.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/executor-http/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/executor-legacy-ws": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.17.tgz",
-      "integrity": "sha512-TvltY6eL4DY1Vt66Z8kt9jVmNcI+WkvVPQZrPbMCM3rv2Jw/sWvSwzUBezRuWX0sIckMifYVh23VPcGBUKX/wg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.8.6",
-        "@types/ws": "^8.0.0",
-        "isomorphic-ws": "^5.0.0",
-        "tslib": "^2.4.0",
-        "ws": "^8.17.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/graphql-file-loader": {
-      "version": "8.0.19",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.19.tgz",
-      "integrity": "sha512-kyEZL4rRJ5LelfCXL3GLgbMiu5Zd7memZaL8ZxPXGI7DA8On1e5IVBH3zZJwf7LzhjSVnPaHM7O/bRzGvTbXzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/import": "7.0.18",
-        "@graphql-tools/utils": "^10.8.6",
-        "globby": "^11.0.3",
-        "tslib": "^2.4.0",
-        "unixify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/graphql-tag-pluck": {
-      "version": "8.3.19",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.19.tgz",
-      "integrity": "sha512-LEw/6IYOUz48HjbWntZXDCzSXsOIM1AyWZrlLoJOrA8QAlhFd8h5Tny7opCypj8FO9VvpPFugWoNDh5InPOEQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/plugin-syntax-import-assertions": "^7.26.0",
-        "@babel/traverse": "^7.26.10",
-        "@babel/types": "^7.26.10",
-        "@graphql-tools/utils": "^10.8.6",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/import": {
-      "version": "7.0.18",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.18.tgz",
-      "integrity": "sha512-1tw1/1QLB0n5bPWfIrhCRnrHIlbMvbwuifDc98g4FPhJ7OXD+iUQe+IpmD5KHVwYWXWhZOuJuq45DfV/WLNq3A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.8.6",
-        "resolve-from": "5.0.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/json-file-loader": {
-      "version": "8.0.18",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.18.tgz",
-      "integrity": "sha512-JjjIxxewgk8HeMR3npR3YbOkB7fxmdgmqB9kZLWdkRKBxrRXVzhryyq+mhmI0Evzt6pNoHIc3vqwmSctG2sddg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.8.6",
-        "globby": "^11.0.3",
-        "tslib": "^2.4.0",
-        "unixify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/load": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.1.0.tgz",
-      "integrity": "sha512-OGfOm09VyXdNGJS/rLqZ6ztCiG2g6AMxhwtET8GZXTbnjptFc17GtKwJ3Jv5w7mjJ8dn0BHydvIuEKEUK4ciYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/schema": "^10.0.23",
-        "@graphql-tools/utils": "^10.8.6",
-        "p-limit": "3.1.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/merge": {
-      "version": "9.0.24",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.24.tgz",
-      "integrity": "sha512-NzWx/Afl/1qHT3Nm1bghGG2l4jub28AdvtG11PoUlmjcIjnFBJMv4vqL0qnxWe8A82peWo4/TkVdjJRLXwgGEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.8.6",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/schema": {
-      "version": "10.0.23",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.23.tgz",
-      "integrity": "sha512-aEGVpd1PCuGEwqTXCStpEkmheTHNdMayiIKH1xDWqYp9i8yKv9FRDgkGrY4RD8TNxnf7iII+6KOBGaJ3ygH95A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/merge": "^9.0.24",
-        "@graphql-tools/utils": "^10.8.6",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/url-loader": {
-      "version": "8.0.31",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.31.tgz",
-      "integrity": "sha512-QGP3py6DAdKERHO5D38Oi+6j+v0O3rkBbnLpyOo87rmIRbwE6sOkL5JeHegHs7EEJ279fBX6lMt8ry0wBMGtyA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/executor-graphql-ws": "^2.0.1",
-        "@graphql-tools/executor-http": "^1.1.9",
-        "@graphql-tools/executor-legacy-ws": "^1.1.17",
-        "@graphql-tools/utils": "^10.8.6",
-        "@graphql-tools/wrap": "^10.0.16",
-        "@types/ws": "^8.0.0",
-        "@whatwg-node/fetch": "^0.10.0",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "isomorphic-ws": "^5.0.0",
-        "sync-fetch": "0.6.0-2",
-        "tslib": "^2.4.0",
-        "ws": "^8.17.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/utils": {
       "version": "10.8.6",
       "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
@@ -3406,33 +3056,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/wrap": {
-      "version": "10.0.35",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.35.tgz",
-      "integrity": "sha512-qBga3wo7+GqY+ClGexiyRz9xgy1RWozZryTuGX8usGWPa4wKi/tJS4rKWQQesgB3Fh//SZUCRA5u2nwZaZQw1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/delegate": "^10.2.17",
-        "@graphql-tools/schema": "^10.0.11",
-        "@graphql-tools/utils": "^10.8.1",
-        "@whatwg-node/promise-helpers": "^1.3.0",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-tools/wrap/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/@graphql-codegen/cli/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3446,16 +3069,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@graphql-codegen/cli/node_modules/chalk": {
@@ -3538,79 +3151,6 @@
         }
       }
     },
-    "node_modules/@graphql-codegen/cli/node_modules/graphql-config": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.1.5.tgz",
-      "integrity": "sha512-mG2LL1HccpU8qg5ajLROgdsBzx/o2M6kgI3uAmoaXiSH9PCUbtIyLomLqUtCFaAeG2YCFsl0M5cfQ9rKmDoMVA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/graphql-file-loader": "^8.0.0",
-        "@graphql-tools/json-file-loader": "^8.0.0",
-        "@graphql-tools/load": "^8.1.0",
-        "@graphql-tools/merge": "^9.0.0",
-        "@graphql-tools/url-loader": "^8.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "cosmiconfig": "^8.1.0",
-        "jiti": "^2.0.0",
-        "minimatch": "^9.0.5",
-        "string-env-interpolation": "^1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "peerDependencies": {
-        "cosmiconfig-toml-loader": "^1.0.0",
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      },
-      "peerDependenciesMeta": {
-        "cosmiconfig-toml-loader": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/graphql-config/node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/graphql-ws": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.5.tgz",
-      "integrity": "sha512-HzYw057ch0hx2gZjkbgk1pur4kAtgljlWRP+Gccudqm3BRrTpExjWCQ9OHdIsq47Y6lHL++1lTvuQHhgRRcevw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@fastify/websocket": "^10 || ^11",
-        "crossws": "~0.3",
-        "graphql": "^15.10.1 || ^16",
-        "uWebSockets.js": "^20",
-        "ws": "^8"
-      },
-      "peerDependenciesMeta": {
-        "@fastify/websocket": {
-          "optional": true
-        },
-        "crossws": {
-          "optional": true
-        },
-        "uWebSockets.js": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@graphql-codegen/cli/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3618,22 +3158,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@graphql-codegen/cli/node_modules/supports-color": {
@@ -3818,41 +3342,6 @@
       },
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/core/node_modules/@graphql-tools/merge": {
-      "version": "9.0.24",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.24.tgz",
-      "integrity": "sha512-NzWx/Afl/1qHT3Nm1bghGG2l4jub28AdvtG11PoUlmjcIjnFBJMv4vqL0qnxWe8A82peWo4/TkVdjJRLXwgGEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.8.6",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/core/node_modules/@graphql-tools/schema": {
-      "version": "10.0.23",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.23.tgz",
-      "integrity": "sha512-aEGVpd1PCuGEwqTXCStpEkmheTHNdMayiIKH1xDWqYp9i8yKv9FRDgkGrY4RD8TNxnf7iII+6KOBGaJ3ygH95A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/merge": "^9.0.24",
-        "@graphql-tools/utils": "^10.8.6",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-codegen/core/node_modules/@graphql-tools/utils": {
@@ -5065,121 +4554,58 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-eslint/eslint-plugin": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-3.20.1.tgz",
-      "integrity": "sha512-RbwVlz1gcYG62sECR1u0XqMh8w5e5XMCCZoMvPQ3nJzEBCTfXLGX727GBoRmSvY1x4gJmqNZ1lsOX7lZY14RIw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-4.4.0.tgz",
+      "integrity": "sha512-dhW6fpk3Souuaphhc38uMAGCcgKMgtCJWFygIKODw/Kns43wiQqRPVay0aNFY1JBx3aevn4KPT/BCOdm6HNncA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.18.6",
-        "@graphql-tools/code-file-loader": "^7.3.6",
-        "@graphql-tools/graphql-tag-pluck": "^7.3.6",
-        "@graphql-tools/utils": "^9.0.0",
-        "chalk": "^4.1.2",
+        "@graphql-tools/code-file-loader": "^8.0.0",
+        "@graphql-tools/graphql-tag-pluck": "^8.3.4",
+        "@graphql-tools/utils": "^10.0.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.2.12",
-        "graphql-config": "^4.4.0",
+        "graphql-config": "^5.1.3",
         "graphql-depth-limit": "^1.1.0",
-        "lodash.lowercase": "^4.3.0",
-        "tslib": "^2.4.1"
+        "lodash.lowercase": "^4.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+        "@apollo/subgraph": "^2",
+        "eslint": ">=8.44.0",
+        "graphql": "^16",
+        "json-schema-to-ts": "^3"
+      },
+      "peerDependenciesMeta": {
+        "@apollo/subgraph": {
+          "optional": true
+        },
+        "json-schema-to-ts": {
+          "optional": true
+        }
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
-    },
-    "node_modules/@graphql-eslint/eslint-plugin/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@graphql-eslint/eslint-plugin/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@graphql-eslint/eslint-plugin/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@graphql-eslint/eslint-plugin/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@graphql-eslint/eslint-plugin/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@graphql-eslint/eslint-plugin/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@graphql-eslint/eslint-plugin/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/@graphql-hive/signal": {
       "version": "1.0.0",
@@ -5231,100 +4657,141 @@
       }
     },
     "node_modules/@graphql-tools/batch-execute": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.22.tgz",
-      "integrity": "sha512-hcV1JaY6NJQFQEwCKrYhpfLK8frSXDbtNMoTur98u10Cmecy1zrqNKSqhEyGetpgHxaJRqszGzKeI3RuroDN6A==",
+      "version": "9.0.16",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.16.tgz",
+      "integrity": "sha512-sLAzEPrmrMTJrlNqmmsc34DtMA//FsoTsGC3V5bHA+EnNlwbwhsSQBSNXvIwsPLRSRwSjGKOpDG7KSxldDe2Rg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^9.2.1",
-        "dataloader": "^2.2.2",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "@graphql-tools/utils": "^10.8.1",
+        "@whatwg-node/promise-helpers": "^1.3.0",
+        "dataloader": "^2.2.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/batch-execute/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@graphql-tools/batch-execute/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/@graphql-tools/code-file-loader": {
-      "version": "7.3.23",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.3.23.tgz",
-      "integrity": "sha512-8Wt1rTtyTEs0p47uzsPJ1vAtfAx0jmxPifiNdmo9EOCuUPyQGEbMaik/YkqZ7QUFIEYEQu+Vgfo8tElwOPtx5Q==",
+      "version": "8.1.20",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.20.tgz",
+      "integrity": "sha512-GzIbjjWJIc04KWnEr8VKuPe0FA2vDTlkaeub5p4lLimljnJ6C0QSkOyCUnFmsB9jetQcHm0Wfmn/akMnFUG+wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/graphql-tag-pluck": "7.5.2",
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/graphql-tag-pluck": "8.3.19",
+        "@graphql-tools/utils": "^10.8.6",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/code-file-loader/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "9.0.35",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.35.tgz",
-      "integrity": "sha512-jwPu8NJbzRRMqi4Vp/5QX1vIUeUPpWmlQpOkXQD2r1X45YsVceyUUBnktCrlJlDB4jPRVy7JQGwmYo3KFiOBMA==",
+      "version": "10.2.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.2.18.tgz",
+      "integrity": "sha512-UynhjLwBZUapjNSHJ7FhGMd7/sRjqB7nk6EcYDZFWQkACTaQKa14Vkv2y2O6rEu61xQxP3/E1+fr/mLn46Zf9A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/batch-execute": "^8.5.22",
-        "@graphql-tools/executor": "^0.0.20",
-        "@graphql-tools/schema": "^9.0.19",
-        "@graphql-tools/utils": "^9.2.1",
-        "dataloader": "^2.2.2",
-        "tslib": "^2.5.0",
-        "value-or-promise": "^1.0.12"
+        "@graphql-tools/batch-execute": "^9.0.16",
+        "@graphql-tools/executor": "^1.4.7",
+        "@graphql-tools/schema": "^10.0.11",
+        "@graphql-tools/utils": "^10.8.1",
+        "@repeaterjs/repeater": "^3.0.6",
+        "@whatwg-node/promise-helpers": "^1.3.0",
+        "dataloader": "^2.2.3",
+        "dset": "^3.1.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/delegate/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@graphql-tools/documents": {
       "version": "1.0.1",
@@ -5344,16 +4811,21 @@
       }
     },
     "node_modules/@graphql-tools/executor": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-0.0.20.tgz",
-      "integrity": "sha512-GdvNc4vszmfeGvUqlcaH1FjBoguvMYzxAfT6tDd4/LgwymepHhinqLNA5otqwVLW+JETcDaK7xGENzFomuE6TA==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.4.7.tgz",
+      "integrity": "sha512-U0nK9jzJRP9/9Izf1+0Gggd6K6RNRsheFo1gC/VWzfnsr0qjcOSS9qTjY0OTC5iTPt4tQ+W5Zpw/uc7mebI6aA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^9.2.1",
-        "@graphql-typed-document-node/core": "3.2.0",
+        "@graphql-tools/utils": "^10.8.6",
+        "@graphql-typed-document-node/core": "^3.2.0",
         "@repeaterjs/repeater": "^3.0.4",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -5397,166 +4869,160 @@
       }
     },
     "node_modules/@graphql-tools/executor-graphql-ws": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-0.0.14.tgz",
-      "integrity": "sha512-P2nlkAsPZKLIXImFhj0YTtny5NQVGSsKnhi7PzXiaHSXc6KkzqbWZHKvikD4PObanqg+7IO58rKFpGXP7eeO+w==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-2.0.5.tgz",
+      "integrity": "sha512-gI/D9VUzI1Jt1G28GYpvm5ckupgJ5O8mi5Y657UyuUozX34ErfVdZ81g6oVcKFQZ60LhCzk7jJeykK48gaLhDw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^9.2.1",
-        "@repeaterjs/repeater": "3.0.4",
-        "@types/ws": "^8.0.0",
-        "graphql-ws": "5.12.1",
-        "isomorphic-ws": "5.0.0",
-        "tslib": "^2.4.0",
-        "ws": "8.13.0"
+        "@graphql-tools/executor-common": "^0.0.4",
+        "@graphql-tools/utils": "^10.8.1",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "graphql-ws": "^6.0.3",
+        "isomorphic-ws": "^5.0.0",
+        "tslib": "^2.8.1",
+        "ws": "^8.17.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/executor-graphql-ws/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/executor-graphql-ws/node_modules/@repeaterjs/repeater": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
-      "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
-      "dev": true
-    },
-    "node_modules/@graphql-tools/executor-graphql-ws/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+    "node_modules/@graphql-tools/executor-graphql-ws/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
+      "license": "0BSD"
     },
     "node_modules/@graphql-tools/executor-http": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-0.1.10.tgz",
-      "integrity": "sha512-hnAfbKv0/lb9s31LhWzawQ5hghBfHS+gYWtqxME6Rl0Aufq9GltiiLBcl7OVVOnkLF0KhwgbYP1mB5VKmgTGpg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.3.3.tgz",
+      "integrity": "sha512-LIy+l08/Ivl8f8sMiHW2ebyck59JzyzO/yF9SFS4NH6MJZUezA1xThUXCDIKhHiD56h/gPojbkpcFvM2CbNE7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-hive/signal": "^1.0.0",
+        "@graphql-tools/executor-common": "^0.0.4",
+        "@graphql-tools/utils": "^10.8.1",
         "@repeaterjs/repeater": "^3.0.4",
-        "@whatwg-node/fetch": "^0.8.1",
-        "dset": "^3.1.2",
-        "extract-files": "^11.0.0",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/fetch": "^0.10.4",
+        "@whatwg-node/promise-helpers": "^1.3.0",
         "meros": "^1.2.1",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/executor-http/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/executor-http/node_modules/@whatwg-node/fetch": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
-      "integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
+    "node_modules/@graphql-tools/executor-http/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "dependencies": {
-        "@peculiar/webcrypto": "^1.4.0",
-        "@whatwg-node/node-fetch": "^0.3.6",
-        "busboy": "^1.6.0",
-        "urlpattern-polyfill": "^8.0.0",
-        "web-streams-polyfill": "^3.2.1"
-      }
+      "license": "0BSD"
     },
     "node_modules/@graphql-tools/executor-legacy-ws": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-0.0.11.tgz",
-      "integrity": "sha512-4ai+NnxlNfvIQ4c70hWFvOZlSUN8lt7yc+ZsrwtNFbFPH/EroIzFMapAxM9zwyv9bH38AdO3TQxZ5zNxgBdvUw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.17.tgz",
+      "integrity": "sha512-TvltY6eL4DY1Vt66Z8kt9jVmNcI+WkvVPQZrPbMCM3rv2Jw/sWvSwzUBezRuWX0sIckMifYVh23VPcGBUKX/wg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/utils": "^10.8.6",
         "@types/ws": "^8.0.0",
-        "isomorphic-ws": "5.0.0",
+        "isomorphic-ws": "^5.0.0",
         "tslib": "^2.4.0",
-        "ws": "8.13.0"
+        "ws": "^8.17.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/executor-legacy-ws/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/executor-legacy-ws/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@graphql-tools/executor/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -5575,28 +5041,6 @@
         "micromatch": "^4.0.8",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/git-loader/node_modules/@graphql-tools/graphql-tag-pluck": {
-      "version": "8.3.19",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.19.tgz",
-      "integrity": "sha512-LEw/6IYOUz48HjbWntZXDCzSXsOIM1AyWZrlLoJOrA8QAlhFd8h5Tny7opCypj8FO9VvpPFugWoNDh5InPOEQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/plugin-syntax-import-assertions": "^7.26.0",
-        "@babel/traverse": "^7.26.10",
-        "@babel/types": "^7.26.10",
-        "@graphql-tools/utils": "^10.8.6",
-        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -5647,52 +5091,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/github-loader/node_modules/@graphql-tools/executor-http": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.3.3.tgz",
-      "integrity": "sha512-LIy+l08/Ivl8f8sMiHW2ebyck59JzyzO/yF9SFS4NH6MJZUezA1xThUXCDIKhHiD56h/gPojbkpcFvM2CbNE7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-hive/signal": "^1.0.0",
-        "@graphql-tools/executor-common": "^0.0.4",
-        "@graphql-tools/utils": "^10.8.1",
-        "@repeaterjs/repeater": "^3.0.4",
-        "@whatwg-node/disposablestack": "^0.0.6",
-        "@whatwg-node/fetch": "^0.10.4",
-        "@whatwg-node/promise-helpers": "^1.3.0",
-        "meros": "^1.2.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/github-loader/node_modules/@graphql-tools/graphql-tag-pluck": {
-      "version": "8.3.19",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.19.tgz",
-      "integrity": "sha512-LEw/6IYOUz48HjbWntZXDCzSXsOIM1AyWZrlLoJOrA8QAlhFd8h5Tny7opCypj8FO9VvpPFugWoNDh5InPOEQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/plugin-syntax-import-assertions": "^7.26.0",
-        "@babel/traverse": "^7.26.10",
-        "@babel/types": "^7.26.10",
-        "@graphql-tools/utils": "^10.8.6",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/github-loader/node_modules/@graphql-tools/utils": {
       "version": "10.8.6",
       "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
@@ -5721,135 +5119,235 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.5.tgz",
-      "integrity": "sha512-OL+7qO1S66TpMK7OGz8Ag2WL08HlxKxrObVSDlxzWbSubWuXM5v959XscYAKRf6daYcVpkfNvO37QjflL9mjhg==",
+      "version": "8.0.19",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.19.tgz",
+      "integrity": "sha512-kyEZL4rRJ5LelfCXL3GLgbMiu5Zd7memZaL8ZxPXGI7DA8On1e5IVBH3zZJwf7LzhjSVnPaHM7O/bRzGvTbXzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/import": "6.7.6",
-        "@graphql-tools/utils": "8.12.0",
+        "@graphql-tools/import": "7.0.18",
+        "@graphql-tools/utils": "^10.8.6",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/graphql-file-loader/node_modules/@graphql-tools/utils": {
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/graphql-tag-pluck": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.5.2.tgz",
-      "integrity": "sha512-RW+H8FqOOLQw0BPXaahYepVSRjuOHw+7IL8Opaa5G5uYGOBxoXR7DceyQ7BcpMgktAOOmpDNQ2WtcboChOJSRA==",
+      "version": "8.3.19",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.19.tgz",
+      "integrity": "sha512-LEw/6IYOUz48HjbWntZXDCzSXsOIM1AyWZrlLoJOrA8QAlhFd8h5Tny7opCypj8FO9VvpPFugWoNDh5InPOEQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.16.8",
-        "@babel/plugin-syntax-import-assertions": "^7.20.0",
-        "@babel/traverse": "^7.16.8",
-        "@babel/types": "^7.16.8",
-        "@graphql-tools/utils": "^9.2.1",
+        "@babel/core": "^7.26.10",
+        "@babel/parser": "^7.26.10",
+        "@babel/plugin-syntax-import-assertions": "^7.26.0",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
+        "@graphql-tools/utils": "^10.8.6",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/import": {
-      "version": "6.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.6.tgz",
-      "integrity": "sha512-WtUyiO2qCaK/H4u81zAw/NbBvCOzwKl4N+Vl+FqrFCzYobscwL6x6roePyoXM1O3+JJIIn3CETv4kg4kwxaBVw==",
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.18.tgz",
+      "integrity": "sha512-1tw1/1QLB0n5bPWfIrhCRnrHIlbMvbwuifDc98g4FPhJ7OXD+iUQe+IpmD5KHVwYWXWhZOuJuq45DfV/WLNq3A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "8.12.0",
+        "@graphql-tools/utils": "^10.8.6",
         "resolve-from": "5.0.0",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/import/node_modules/@graphql-tools/utils": {
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/json-file-loader": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.4.6.tgz",
-      "integrity": "sha512-34AfjCitO4NtJ5AcXYLcFF3GDsMVTycrljSaBA2t1d7B4bMPtREDphKXLMc/Uf2zW6IW1i1sZZyrcmArPy1Z8A==",
+      "version": "8.0.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.18.tgz",
+      "integrity": "sha512-JjjIxxewgk8HeMR3npR3YbOkB7fxmdgmqB9kZLWdkRKBxrRXVzhryyq+mhmI0Evzt6pNoHIc3vqwmSctG2sddg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "8.12.0",
+        "@graphql-tools/utils": "^10.8.6",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/json-file-loader/node_modules/@graphql-tools/utils": {
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/load": {
-      "version": "7.8.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.8.14.tgz",
-      "integrity": "sha512-ASQvP+snHMYm+FhIaLxxFgVdRaM0vrN9wW2BKInQpktwWTXVyk+yP5nQUCEGmn0RTdlPKrffBaigxepkEAJPrg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.1.0.tgz",
+      "integrity": "sha512-OGfOm09VyXdNGJS/rLqZ6ztCiG2g6AMxhwtET8GZXTbnjptFc17GtKwJ3Jv5w7mjJ8dn0BHydvIuEKEUK4ciYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/schema": "^9.0.18",
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/schema": "^10.0.23",
+        "@graphql-tools/utils": "^10.8.6",
         "p-limit": "3.1.0",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/load/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
-      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+      "version": "9.0.24",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.24.tgz",
+      "integrity": "sha512-NzWx/Afl/1qHT3Nm1bghGG2l4jub28AdvtG11PoUlmjcIjnFBJMv4vqL0qnxWe8A82peWo4/TkVdjJRLXwgGEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/utils": "^10.8.6",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -5899,198 +5397,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/batch-execute": {
-      "version": "9.0.15",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.15.tgz",
-      "integrity": "sha512-qlWUl6yi87FU5WvyJ0uD81R4Y30oQIuW3mJCjOrEvifyT+f/rEqSZFOhYrofYoZAoTcwqOhy6WgH+b9+AtRYjA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.8.1",
-        "@whatwg-node/promise-helpers": "^1.3.0",
-        "dataloader": "^2.2.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/delegate": {
-      "version": "10.2.17",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.2.17.tgz",
-      "integrity": "sha512-z+LpZrTQCEXA4fbdJcSsvhaMqT4xi/O8B0mP30ENGyTbSfa20QamOQx9jgCiw2ii/ucwxfGMhygwlpZG36EU4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/batch-execute": "^9.0.15",
-        "@graphql-tools/executor": "^1.4.7",
-        "@graphql-tools/schema": "^10.0.11",
-        "@graphql-tools/utils": "^10.8.1",
-        "@repeaterjs/repeater": "^3.0.6",
-        "@whatwg-node/promise-helpers": "^1.3.0",
-        "dataloader": "^2.2.3",
-        "dset": "^3.1.2",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/executor": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.4.7.tgz",
-      "integrity": "sha512-U0nK9jzJRP9/9Izf1+0Gggd6K6RNRsheFo1gC/VWzfnsr0qjcOSS9qTjY0OTC5iTPt4tQ+W5Zpw/uc7mebI6aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.8.6",
-        "@graphql-typed-document-node/core": "^3.2.0",
-        "@repeaterjs/repeater": "^3.0.4",
-        "@whatwg-node/disposablestack": "^0.0.6",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/executor-graphql-ws": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-2.0.5.tgz",
-      "integrity": "sha512-gI/D9VUzI1Jt1G28GYpvm5ckupgJ5O8mi5Y657UyuUozX34ErfVdZ81g6oVcKFQZ60LhCzk7jJeykK48gaLhDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/executor-common": "^0.0.4",
-        "@graphql-tools/utils": "^10.8.1",
-        "@whatwg-node/disposablestack": "^0.0.6",
-        "graphql-ws": "^6.0.3",
-        "isomorphic-ws": "^5.0.0",
-        "tslib": "^2.8.1",
-        "ws": "^8.17.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/executor-http": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.3.3.tgz",
-      "integrity": "sha512-LIy+l08/Ivl8f8sMiHW2ebyck59JzyzO/yF9SFS4NH6MJZUezA1xThUXCDIKhHiD56h/gPojbkpcFvM2CbNE7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-hive/signal": "^1.0.0",
-        "@graphql-tools/executor-common": "^0.0.4",
-        "@graphql-tools/utils": "^10.8.1",
-        "@repeaterjs/repeater": "^3.0.4",
-        "@whatwg-node/disposablestack": "^0.0.6",
-        "@whatwg-node/fetch": "^0.10.4",
-        "@whatwg-node/promise-helpers": "^1.3.0",
-        "meros": "^1.2.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/executor-legacy-ws": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.17.tgz",
-      "integrity": "sha512-TvltY6eL4DY1Vt66Z8kt9jVmNcI+WkvVPQZrPbMCM3rv2Jw/sWvSwzUBezRuWX0sIckMifYVh23VPcGBUKX/wg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.8.6",
-        "@types/ws": "^8.0.0",
-        "isomorphic-ws": "^5.0.0",
-        "tslib": "^2.4.0",
-        "ws": "^8.17.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/merge": {
-      "version": "9.0.24",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.24.tgz",
-      "integrity": "sha512-NzWx/Afl/1qHT3Nm1bghGG2l4jub28AdvtG11PoUlmjcIjnFBJMv4vqL0qnxWe8A82peWo4/TkVdjJRLXwgGEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.8.6",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/schema": {
-      "version": "10.0.23",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.23.tgz",
-      "integrity": "sha512-aEGVpd1PCuGEwqTXCStpEkmheTHNdMayiIKH1xDWqYp9i8yKv9FRDgkGrY4RD8TNxnf7iII+6KOBGaJ3ygH95A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/merge": "^9.0.24",
-        "@graphql-tools/utils": "^10.8.6",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/url-loader": {
-      "version": "8.0.31",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.31.tgz",
-      "integrity": "sha512-QGP3py6DAdKERHO5D38Oi+6j+v0O3rkBbnLpyOo87rmIRbwE6sOkL5JeHegHs7EEJ279fBX6lMt8ry0wBMGtyA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/executor-graphql-ws": "^2.0.1",
-        "@graphql-tools/executor-http": "^1.1.9",
-        "@graphql-tools/executor-legacy-ws": "^1.1.17",
-        "@graphql-tools/utils": "^10.8.6",
-        "@graphql-tools/wrap": "^10.0.16",
-        "@types/ws": "^8.0.0",
-        "@whatwg-node/fetch": "^0.10.0",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "isomorphic-ws": "^5.0.0",
-        "sync-fetch": "0.6.0-2",
-        "tslib": "^2.4.0",
-        "ws": "^8.17.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/utils": {
       "version": "10.8.6",
       "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
@@ -6106,26 +5412,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/wrap": {
-      "version": "10.0.35",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.35.tgz",
-      "integrity": "sha512-qBga3wo7+GqY+ClGexiyRz9xgy1RWozZryTuGX8usGWPa4wKi/tJS4rKWQQesgB3Fh//SZUCRA5u2nwZaZQw1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/delegate": "^10.2.17",
-        "@graphql-tools/schema": "^10.0.11",
-        "@graphql-tools/utils": "^10.8.1",
-        "@whatwg-node/promise-helpers": "^1.3.0",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -6193,37 +5479,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@graphql-tools/prisma-loader/node_modules/graphql-ws": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.5.tgz",
-      "integrity": "sha512-HzYw057ch0hx2gZjkbgk1pur4kAtgljlWRP+Gccudqm3BRrTpExjWCQ9OHdIsq47Y6lHL++1lTvuQHhgRRcevw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@fastify/websocket": "^10 || ^11",
-        "crossws": "~0.3",
-        "graphql": "^15.10.1 || ^16",
-        "uWebSockets.js": "^20",
-        "ws": "^8"
-      },
-      "peerDependenciesMeta": {
-        "@fastify/websocket": {
-          "optional": true
-        },
-        "crossws": {
-          "optional": true
-        },
-        "uWebSockets.js": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@graphql-tools/prisma-loader/node_modules/has-flag": {
       "version": "4.0.0",
@@ -6299,83 +5554,88 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "9.0.19",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
-      "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+      "version": "10.0.23",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.23.tgz",
+      "integrity": "sha512-aEGVpd1PCuGEwqTXCStpEkmheTHNdMayiIKH1xDWqYp9i8yKv9FRDgkGrY4RD8TNxnf7iII+6KOBGaJ3ygH95A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^8.4.1",
-        "@graphql-tools/utils": "^9.2.1",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "@graphql-tools/merge": "^9.0.24",
+        "@graphql-tools/utils": "^10.8.6",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/url-loader": {
-      "version": "7.17.18",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.17.18.tgz",
-      "integrity": "sha512-ear0CiyTj04jCVAxi7TvgbnGDIN2HgqzXzwsfcqiVg9cvjT40NcMlZ2P1lZDgqMkZ9oyLTV8Bw6j+SyG6A+xPw==",
+      "version": "8.0.31",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.31.tgz",
+      "integrity": "sha512-QGP3py6DAdKERHO5D38Oi+6j+v0O3rkBbnLpyOo87rmIRbwE6sOkL5JeHegHs7EEJ279fBX6lMt8ry0wBMGtyA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@ardatan/sync-fetch": "^0.0.1",
-        "@graphql-tools/delegate": "^9.0.31",
-        "@graphql-tools/executor-graphql-ws": "^0.0.14",
-        "@graphql-tools/executor-http": "^0.1.7",
-        "@graphql-tools/executor-legacy-ws": "^0.0.11",
-        "@graphql-tools/utils": "^9.2.1",
-        "@graphql-tools/wrap": "^9.4.2",
+        "@graphql-tools/executor-graphql-ws": "^2.0.1",
+        "@graphql-tools/executor-http": "^1.1.9",
+        "@graphql-tools/executor-legacy-ws": "^1.1.17",
+        "@graphql-tools/utils": "^10.8.6",
+        "@graphql-tools/wrap": "^10.0.16",
         "@types/ws": "^8.0.0",
-        "@whatwg-node/fetch": "^0.8.0",
+        "@whatwg-node/fetch": "^0.10.0",
+        "@whatwg-node/promise-helpers": "^1.0.0",
         "isomorphic-ws": "^5.0.0",
+        "sync-fetch": "0.6.0-2",
         "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.11",
-        "ws": "^8.12.0"
+        "ws": "^8.17.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/url-loader/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/url-loader/node_modules/@whatwg-node/fetch": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
-      "integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
-      "dev": true,
-      "dependencies": {
-        "@peculiar/webcrypto": "^1.4.0",
-        "@whatwg-node/node-fetch": "^0.3.6",
-        "busboy": "^1.6.0",
-        "urlpattern-polyfill": "^8.0.0",
-        "web-streams-polyfill": "^3.2.1"
       }
     },
     "node_modules/@graphql-tools/utils": {
@@ -6391,33 +5651,51 @@
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.4.2.tgz",
-      "integrity": "sha512-DFcd9r51lmcEKn0JW43CWkkI2D6T9XI1juW/Yo86i04v43O9w2/k4/nx2XTJv4Yv+iXwUw7Ok81PGltwGJSDSA==",
+      "version": "10.0.36",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.36.tgz",
+      "integrity": "sha512-sLm9j/T6mlKklSMOCDjrGMi39MRAUzRXsc8tTugZZl0yJEtfU7tX1UaYJQNVsar7vkjLofaWtS7Jf6vcWgGYgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/delegate": "^9.0.31",
-        "@graphql-tools/schema": "^9.0.18",
-        "@graphql-tools/utils": "^9.2.1",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "@graphql-tools/delegate": "^10.2.18",
+        "@graphql-tools/schema": "^10.0.11",
+        "@graphql-tools/utils": "^10.8.1",
+        "@whatwg-node/promise-helpers": "^1.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
+    },
+    "node_modules/@graphql-tools/wrap/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.2.0",
@@ -8023,45 +7301,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.0.tgz",
-      "integrity": "sha512-DtNLAG4vmDrdSJFPe7rypkcj597chNQL7u+2dBtYo5mh7VW2+im6ke+O0NVr8W1f4re4C3F71LhoMb0Yxqa48Q==",
-      "dev": true,
-      "dependencies": {
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz",
-      "integrity": "sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==",
-      "dev": true,
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.1.6",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0",
-        "webcrypto-core": "^1.7.4"
-      },
-      "engines": {
-        "node": ">=10.12.0"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -9966,12 +9205,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/@whatwg-node/events": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
-      "integrity": "sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA==",
-      "dev": true
-    },
     "node_modules/@whatwg-node/fetch": {
       "version": "0.10.7",
       "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.7.tgz",
@@ -10015,19 +9248,6 @@
       "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@whatwg-node/node-fetch": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz",
-      "integrity": "sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==",
-      "dev": true,
-      "dependencies": {
-        "@whatwg-node/events": "^0.0.3",
-        "busboy": "^1.6.0",
-        "fast-querystring": "^1.1.1",
-        "fast-url-parser": "^1.1.3",
-        "tslib": "^2.3.1"
-      }
     },
     "node_modules/@whatwg-node/promise-helpers": {
       "version": "1.3.2",
@@ -10507,20 +9727,6 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
-    },
-    "node_modules/asn1js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
-      "dev": true,
-      "dependencies": {
-        "pvtsutils": "^1.3.2",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
@@ -11235,18 +10441,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -14265,24 +13459,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/extract-files": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
-      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jaydenseric"
-      }
-    },
-    "node_modules/fast-decode-uri-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "dev": true
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -14317,15 +13493,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/fast-querystring": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
-      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-      "dev": true,
-      "dependencies": {
-        "fast-decode-uri-component": "^1.0.1"
-      }
-    },
     "node_modules/fast-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -14342,21 +13509,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
-    },
-    "node_modules/fast-url-parser/node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -15223,26 +14375,26 @@
       }
     },
     "node_modules/graphql-config": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.5.0.tgz",
-      "integrity": "sha512-x6D0/cftpLUJ0Ch1e5sj1TZn6Wcxx4oMfmhaG9shM0DKajA9iR+j1z86GSTQ19fShbGvrSSvbIQsHku6aQ6BBw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.1.5.tgz",
+      "integrity": "sha512-mG2LL1HccpU8qg5ajLROgdsBzx/o2M6kgI3uAmoaXiSH9PCUbtIyLomLqUtCFaAeG2YCFsl0M5cfQ9rKmDoMVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/graphql-file-loader": "^7.3.7",
-        "@graphql-tools/json-file-loader": "^7.3.7",
-        "@graphql-tools/load": "^7.5.5",
-        "@graphql-tools/merge": "^8.2.6",
-        "@graphql-tools/url-loader": "^7.9.7",
-        "@graphql-tools/utils": "^9.0.0",
-        "cosmiconfig": "8.0.0",
-        "jiti": "1.17.1",
-        "minimatch": "4.2.3",
-        "string-env-interpolation": "1.0.1",
+        "@graphql-tools/graphql-file-loader": "^8.0.0",
+        "@graphql-tools/json-file-loader": "^8.0.0",
+        "@graphql-tools/load": "^8.1.0",
+        "@graphql-tools/merge": "^9.0.0",
+        "@graphql-tools/url-loader": "^8.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "cosmiconfig": "^8.1.0",
+        "jiti": "^2.0.0",
+        "minimatch": "^9.0.5",
+        "string-env-interpolation": "^1.0.1",
         "tslib": "^2.4.0"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 16.0.0"
       },
       "peerDependencies": {
         "cosmiconfig-toml-loader": "^1.0.0",
@@ -15255,46 +14407,86 @@
       }
     },
     "node_modules/graphql-config/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.8.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/graphql-config/node_modules/cosmiconfig": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
-      "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
+    "node_modules/graphql-config/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "import-fresh": "^3.2.1",
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.0.0",
+        "parse-json": "^5.2.0",
         "path-type": "^4.0.0"
       },
       "engines": {
         "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/graphql-config/node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/graphql-config/node_modules/minimatch": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.3.tgz",
-      "integrity": "sha512-lIUdtK5hdofgCTu3aT0sOaHsYR37viUuIc0rwnnDXImbwFRcumyLMeZaM0t0I/fgxS6s6JMfu0rLD1Wz9pv1ng==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/graphql-depth-limit": {
@@ -15341,15 +14533,34 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.12.1.tgz",
-      "integrity": "sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.5.tgz",
+      "integrity": "sha512-HzYw057ch0hx2gZjkbgk1pur4kAtgljlWRP+Gccudqm3BRrTpExjWCQ9OHdIsq47Y6lHL++1lTvuQHhgRRcevw==",
       "devOptional": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "graphql": ">=0.11 <=16"
+        "@fastify/websocket": "^10 || ^11",
+        "crossws": "~0.3",
+        "graphql": "^15.10.1 || ^16",
+        "uWebSockets.js": "^20",
+        "ws": "^8"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/websocket": {
+          "optional": true
+        },
+        "crossws": {
+          "optional": true
+        },
+        "uWebSockets.js": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/gzip-size": {
@@ -23430,24 +22641,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pvtsutils": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
-      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/pvutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -25401,15 +24594,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -26903,12 +26087,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/urlpattern-polyfill": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
-      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
-      "dev": true
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -26983,16 +26161,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/value-or-promise": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
-      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/vary": {
@@ -27142,19 +26310,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/webcrypto-core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.5.tgz",
-      "integrity": "sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==",
-      "dev": true,
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.1.6",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.1",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -28371,15 +27526,6 @@
             "decamelize": "^1.2.0"
           }
         }
-      }
-    },
-    "@ardatan/sync-fetch": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
-      "integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^2.6.1"
       }
     },
     "@arrows/composition": {
@@ -30196,243 +29342,6 @@
             "tslib": "~2.6.0"
           }
         },
-        "@graphql-tools/batch-execute": {
-          "version": "9.0.15",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.15.tgz",
-          "integrity": "sha512-qlWUl6yi87FU5WvyJ0uD81R4Y30oQIuW3mJCjOrEvifyT+f/rEqSZFOhYrofYoZAoTcwqOhy6WgH+b9+AtRYjA==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^10.8.1",
-            "@whatwg-node/promise-helpers": "^1.3.0",
-            "dataloader": "^2.2.3",
-            "tslib": "^2.8.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "2.8.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-              "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-              "dev": true
-            }
-          }
-        },
-        "@graphql-tools/code-file-loader": {
-          "version": "8.1.20",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.20.tgz",
-          "integrity": "sha512-GzIbjjWJIc04KWnEr8VKuPe0FA2vDTlkaeub5p4lLimljnJ6C0QSkOyCUnFmsB9jetQcHm0Wfmn/akMnFUG+wA==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/graphql-tag-pluck": "8.3.19",
-            "@graphql-tools/utils": "^10.8.6",
-            "globby": "^11.0.3",
-            "tslib": "^2.4.0",
-            "unixify": "^1.0.0"
-          }
-        },
-        "@graphql-tools/delegate": {
-          "version": "10.2.17",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.2.17.tgz",
-          "integrity": "sha512-z+LpZrTQCEXA4fbdJcSsvhaMqT4xi/O8B0mP30ENGyTbSfa20QamOQx9jgCiw2ii/ucwxfGMhygwlpZG36EU4w==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/batch-execute": "^9.0.15",
-            "@graphql-tools/executor": "^1.4.7",
-            "@graphql-tools/schema": "^10.0.11",
-            "@graphql-tools/utils": "^10.8.1",
-            "@repeaterjs/repeater": "^3.0.6",
-            "@whatwg-node/promise-helpers": "^1.3.0",
-            "dataloader": "^2.2.3",
-            "dset": "^3.1.2",
-            "tslib": "^2.8.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "2.8.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-              "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-              "dev": true
-            }
-          }
-        },
-        "@graphql-tools/executor": {
-          "version": "1.4.7",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.4.7.tgz",
-          "integrity": "sha512-U0nK9jzJRP9/9Izf1+0Gggd6K6RNRsheFo1gC/VWzfnsr0qjcOSS9qTjY0OTC5iTPt4tQ+W5Zpw/uc7mebI6aA==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^10.8.6",
-            "@graphql-typed-document-node/core": "^3.2.0",
-            "@repeaterjs/repeater": "^3.0.4",
-            "@whatwg-node/disposablestack": "^0.0.6",
-            "@whatwg-node/promise-helpers": "^1.0.0",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@graphql-tools/executor-graphql-ws": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-2.0.5.tgz",
-          "integrity": "sha512-gI/D9VUzI1Jt1G28GYpvm5ckupgJ5O8mi5Y657UyuUozX34ErfVdZ81g6oVcKFQZ60LhCzk7jJeykK48gaLhDw==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/executor-common": "^0.0.4",
-            "@graphql-tools/utils": "^10.8.1",
-            "@whatwg-node/disposablestack": "^0.0.6",
-            "graphql-ws": "^6.0.3",
-            "isomorphic-ws": "^5.0.0",
-            "tslib": "^2.8.1",
-            "ws": "^8.17.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "2.8.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-              "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-              "dev": true
-            }
-          }
-        },
-        "@graphql-tools/executor-http": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.3.3.tgz",
-          "integrity": "sha512-LIy+l08/Ivl8f8sMiHW2ebyck59JzyzO/yF9SFS4NH6MJZUezA1xThUXCDIKhHiD56h/gPojbkpcFvM2CbNE7A==",
-          "dev": true,
-          "requires": {
-            "@graphql-hive/signal": "^1.0.0",
-            "@graphql-tools/executor-common": "^0.0.4",
-            "@graphql-tools/utils": "^10.8.1",
-            "@repeaterjs/repeater": "^3.0.4",
-            "@whatwg-node/disposablestack": "^0.0.6",
-            "@whatwg-node/fetch": "^0.10.4",
-            "@whatwg-node/promise-helpers": "^1.3.0",
-            "meros": "^1.2.1",
-            "tslib": "^2.8.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "2.8.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-              "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-              "dev": true
-            }
-          }
-        },
-        "@graphql-tools/executor-legacy-ws": {
-          "version": "1.1.17",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.17.tgz",
-          "integrity": "sha512-TvltY6eL4DY1Vt66Z8kt9jVmNcI+WkvVPQZrPbMCM3rv2Jw/sWvSwzUBezRuWX0sIckMifYVh23VPcGBUKX/wg==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^10.8.6",
-            "@types/ws": "^8.0.0",
-            "isomorphic-ws": "^5.0.0",
-            "tslib": "^2.4.0",
-            "ws": "^8.17.1"
-          }
-        },
-        "@graphql-tools/graphql-file-loader": {
-          "version": "8.0.19",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.19.tgz",
-          "integrity": "sha512-kyEZL4rRJ5LelfCXL3GLgbMiu5Zd7memZaL8ZxPXGI7DA8On1e5IVBH3zZJwf7LzhjSVnPaHM7O/bRzGvTbXzQ==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/import": "7.0.18",
-            "@graphql-tools/utils": "^10.8.6",
-            "globby": "^11.0.3",
-            "tslib": "^2.4.0",
-            "unixify": "^1.0.0"
-          }
-        },
-        "@graphql-tools/graphql-tag-pluck": {
-          "version": "8.3.19",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.19.tgz",
-          "integrity": "sha512-LEw/6IYOUz48HjbWntZXDCzSXsOIM1AyWZrlLoJOrA8QAlhFd8h5Tny7opCypj8FO9VvpPFugWoNDh5InPOEQA==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.26.10",
-            "@babel/parser": "^7.26.10",
-            "@babel/plugin-syntax-import-assertions": "^7.26.0",
-            "@babel/traverse": "^7.26.10",
-            "@babel/types": "^7.26.10",
-            "@graphql-tools/utils": "^10.8.6",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@graphql-tools/import": {
-          "version": "7.0.18",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.18.tgz",
-          "integrity": "sha512-1tw1/1QLB0n5bPWfIrhCRnrHIlbMvbwuifDc98g4FPhJ7OXD+iUQe+IpmD5KHVwYWXWhZOuJuq45DfV/WLNq3A==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^10.8.6",
-            "resolve-from": "5.0.0",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@graphql-tools/json-file-loader": {
-          "version": "8.0.18",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.18.tgz",
-          "integrity": "sha512-JjjIxxewgk8HeMR3npR3YbOkB7fxmdgmqB9kZLWdkRKBxrRXVzhryyq+mhmI0Evzt6pNoHIc3vqwmSctG2sddg==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^10.8.6",
-            "globby": "^11.0.3",
-            "tslib": "^2.4.0",
-            "unixify": "^1.0.0"
-          }
-        },
-        "@graphql-tools/load": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.1.0.tgz",
-          "integrity": "sha512-OGfOm09VyXdNGJS/rLqZ6ztCiG2g6AMxhwtET8GZXTbnjptFc17GtKwJ3Jv5w7mjJ8dn0BHydvIuEKEUK4ciYw==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/schema": "^10.0.23",
-            "@graphql-tools/utils": "^10.8.6",
-            "p-limit": "3.1.0",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@graphql-tools/merge": {
-          "version": "9.0.24",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.24.tgz",
-          "integrity": "sha512-NzWx/Afl/1qHT3Nm1bghGG2l4jub28AdvtG11PoUlmjcIjnFBJMv4vqL0qnxWe8A82peWo4/TkVdjJRLXwgGEw==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^10.8.6",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@graphql-tools/schema": {
-          "version": "10.0.23",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.23.tgz",
-          "integrity": "sha512-aEGVpd1PCuGEwqTXCStpEkmheTHNdMayiIKH1xDWqYp9i8yKv9FRDgkGrY4RD8TNxnf7iII+6KOBGaJ3ygH95A==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/merge": "^9.0.24",
-            "@graphql-tools/utils": "^10.8.6",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@graphql-tools/url-loader": {
-          "version": "8.0.31",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.31.tgz",
-          "integrity": "sha512-QGP3py6DAdKERHO5D38Oi+6j+v0O3rkBbnLpyOo87rmIRbwE6sOkL5JeHegHs7EEJ279fBX6lMt8ry0wBMGtyA==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/executor-graphql-ws": "^2.0.1",
-            "@graphql-tools/executor-http": "^1.1.9",
-            "@graphql-tools/executor-legacy-ws": "^1.1.17",
-            "@graphql-tools/utils": "^10.8.6",
-            "@graphql-tools/wrap": "^10.0.16",
-            "@types/ws": "^8.0.0",
-            "@whatwg-node/fetch": "^0.10.0",
-            "@whatwg-node/promise-helpers": "^1.0.0",
-            "isomorphic-ws": "^5.0.0",
-            "sync-fetch": "0.6.0-2",
-            "tslib": "^2.4.0",
-            "ws": "^8.17.1"
-          }
-        },
         "@graphql-tools/utils": {
           "version": "10.8.6",
           "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
@@ -30446,27 +29355,6 @@
             "tslib": "^2.4.0"
           }
         },
-        "@graphql-tools/wrap": {
-          "version": "10.0.35",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.35.tgz",
-          "integrity": "sha512-qBga3wo7+GqY+ClGexiyRz9xgy1RWozZryTuGX8usGWPa4wKi/tJS4rKWQQesgB3Fh//SZUCRA5u2nwZaZQw1Q==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/delegate": "^10.2.17",
-            "@graphql-tools/schema": "^10.0.11",
-            "@graphql-tools/utils": "^10.8.1",
-            "@whatwg-node/promise-helpers": "^1.3.0",
-            "tslib": "^2.8.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "2.8.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-              "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-              "dev": true
-            }
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -30474,15 +29362,6 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
-          }
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
           }
         },
         "chalk": {
@@ -30540,54 +29419,11 @@
             "path-type": "^4.0.0"
           }
         },
-        "graphql-config": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.1.5.tgz",
-          "integrity": "sha512-mG2LL1HccpU8qg5ajLROgdsBzx/o2M6kgI3uAmoaXiSH9PCUbtIyLomLqUtCFaAeG2YCFsl0M5cfQ9rKmDoMVA==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/graphql-file-loader": "^8.0.0",
-            "@graphql-tools/json-file-loader": "^8.0.0",
-            "@graphql-tools/load": "^8.1.0",
-            "@graphql-tools/merge": "^9.0.0",
-            "@graphql-tools/url-loader": "^8.0.0",
-            "@graphql-tools/utils": "^10.0.0",
-            "cosmiconfig": "^8.1.0",
-            "jiti": "^2.0.0",
-            "minimatch": "^9.0.5",
-            "string-env-interpolation": "^1.0.1",
-            "tslib": "^2.4.0"
-          },
-          "dependencies": {
-            "jiti": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-              "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-              "dev": true
-            }
-          }
-        },
-        "graphql-ws": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.5.tgz",
-          "integrity": "sha512-HzYw057ch0hx2gZjkbgk1pur4kAtgljlWRP+Gccudqm3BRrTpExjWCQ9OHdIsq47Y6lHL++1lTvuQHhgRRcevw==",
-          "dev": true,
-          "requires": {}
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
-        },
-        "minimatch": {
-          "version": "9.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -30720,27 +29556,6 @@
             "import-from": "4.0.0",
             "lodash": "~4.17.0",
             "tslib": "~2.6.0"
-          }
-        },
-        "@graphql-tools/merge": {
-          "version": "9.0.24",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.24.tgz",
-          "integrity": "sha512-NzWx/Afl/1qHT3Nm1bghGG2l4jub28AdvtG11PoUlmjcIjnFBJMv4vqL0qnxWe8A82peWo4/TkVdjJRLXwgGEw==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^10.8.6",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@graphql-tools/schema": {
-          "version": "10.0.23",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.23.tgz",
-          "integrity": "sha512-aEGVpd1PCuGEwqTXCStpEkmheTHNdMayiIKH1xDWqYp9i8yKv9FRDgkGrY4RD8TNxnf7iII+6KOBGaJ3ygH95A==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/merge": "^9.0.24",
-            "@graphql-tools/utils": "^10.8.6",
-            "tslib": "^2.4.0"
           }
         },
         "@graphql-tools/utils": {
@@ -31673,88 +30488,33 @@
       }
     },
     "@graphql-eslint/eslint-plugin": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-3.20.1.tgz",
-      "integrity": "sha512-RbwVlz1gcYG62sECR1u0XqMh8w5e5XMCCZoMvPQ3nJzEBCTfXLGX727GBoRmSvY1x4gJmqNZ1lsOX7lZY14RIw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-4.4.0.tgz",
+      "integrity": "sha512-dhW6fpk3Souuaphhc38uMAGCcgKMgtCJWFygIKODw/Kns43wiQqRPVay0aNFY1JBx3aevn4KPT/BCOdm6HNncA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.18.6",
-        "@graphql-tools/code-file-loader": "^7.3.6",
-        "@graphql-tools/graphql-tag-pluck": "^7.3.6",
-        "@graphql-tools/utils": "^9.0.0",
-        "chalk": "^4.1.2",
+        "@graphql-tools/code-file-loader": "^8.0.0",
+        "@graphql-tools/graphql-tag-pluck": "^8.3.4",
+        "@graphql-tools/utils": "^10.0.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.2.12",
-        "graphql-config": "^4.4.0",
+        "graphql-config": "^5.1.3",
         "graphql-depth-limit": "^1.1.0",
-        "lodash.lowercase": "^4.3.0",
-        "tslib": "^2.4.1"
+        "lodash.lowercase": "^4.3.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "tslib": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-          "dev": true
         }
       }
     },
@@ -31792,83 +30552,100 @@
       }
     },
     "@graphql-tools/batch-execute": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.22.tgz",
-      "integrity": "sha512-hcV1JaY6NJQFQEwCKrYhpfLK8frSXDbtNMoTur98u10Cmecy1zrqNKSqhEyGetpgHxaJRqszGzKeI3RuroDN6A==",
+      "version": "9.0.16",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.16.tgz",
+      "integrity": "sha512-sLAzEPrmrMTJrlNqmmsc34DtMA//FsoTsGC3V5bHA+EnNlwbwhsSQBSNXvIwsPLRSRwSjGKOpDG7KSxldDe2Rg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^9.2.1",
-        "dataloader": "^2.2.2",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "@graphql-tools/utils": "^10.8.1",
+        "@whatwg-node/promise-helpers": "^1.3.0",
+        "dataloader": "^2.2.3",
+        "tslib": "^2.8.1"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+          "dev": true
         }
       }
     },
     "@graphql-tools/code-file-loader": {
-      "version": "7.3.23",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.3.23.tgz",
-      "integrity": "sha512-8Wt1rTtyTEs0p47uzsPJ1vAtfAx0jmxPifiNdmo9EOCuUPyQGEbMaik/YkqZ7QUFIEYEQu+Vgfo8tElwOPtx5Q==",
+      "version": "8.1.20",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.20.tgz",
+      "integrity": "sha512-GzIbjjWJIc04KWnEr8VKuPe0FA2vDTlkaeub5p4lLimljnJ6C0QSkOyCUnFmsB9jetQcHm0Wfmn/akMnFUG+wA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/graphql-tag-pluck": "7.5.2",
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/graphql-tag-pluck": "8.3.19",
+        "@graphql-tools/utils": "^10.8.6",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
         }
       }
     },
     "@graphql-tools/delegate": {
-      "version": "9.0.35",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.35.tgz",
-      "integrity": "sha512-jwPu8NJbzRRMqi4Vp/5QX1vIUeUPpWmlQpOkXQD2r1X45YsVceyUUBnktCrlJlDB4jPRVy7JQGwmYo3KFiOBMA==",
+      "version": "10.2.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.2.18.tgz",
+      "integrity": "sha512-UynhjLwBZUapjNSHJ7FhGMd7/sRjqB7nk6EcYDZFWQkACTaQKa14Vkv2y2O6rEu61xQxP3/E1+fr/mLn46Zf9A==",
       "dev": true,
       "requires": {
-        "@graphql-tools/batch-execute": "^8.5.22",
-        "@graphql-tools/executor": "^0.0.20",
-        "@graphql-tools/schema": "^9.0.19",
-        "@graphql-tools/utils": "^9.2.1",
-        "dataloader": "^2.2.2",
-        "tslib": "^2.5.0",
-        "value-or-promise": "^1.0.12"
+        "@graphql-tools/batch-execute": "^9.0.16",
+        "@graphql-tools/executor": "^1.4.7",
+        "@graphql-tools/schema": "^10.0.11",
+        "@graphql-tools/utils": "^10.8.1",
+        "@repeaterjs/repeater": "^3.0.6",
+        "@whatwg-node/promise-helpers": "^1.3.0",
+        "dataloader": "^2.2.3",
+        "dset": "^3.1.2",
+        "tslib": "^2.8.1"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
         },
         "tslib": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
           "dev": true
         }
       }
@@ -31884,25 +30661,29 @@
       }
     },
     "@graphql-tools/executor": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-0.0.20.tgz",
-      "integrity": "sha512-GdvNc4vszmfeGvUqlcaH1FjBoguvMYzxAfT6tDd4/LgwymepHhinqLNA5otqwVLW+JETcDaK7xGENzFomuE6TA==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.4.7.tgz",
+      "integrity": "sha512-U0nK9jzJRP9/9Izf1+0Gggd6K6RNRsheFo1gC/VWzfnsr0qjcOSS9qTjY0OTC5iTPt4tQ+W5Zpw/uc7mebI6aA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^9.2.1",
-        "@graphql-typed-document-node/core": "3.2.0",
+        "@graphql-tools/utils": "^10.8.6",
+        "@graphql-typed-document-node/core": "^3.2.0",
         "@repeaterjs/repeater": "^3.0.4",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "tslib": "^2.4.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
         }
@@ -31934,115 +30715,104 @@
       }
     },
     "@graphql-tools/executor-graphql-ws": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-0.0.14.tgz",
-      "integrity": "sha512-P2nlkAsPZKLIXImFhj0YTtny5NQVGSsKnhi7PzXiaHSXc6KkzqbWZHKvikD4PObanqg+7IO58rKFpGXP7eeO+w==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-2.0.5.tgz",
+      "integrity": "sha512-gI/D9VUzI1Jt1G28GYpvm5ckupgJ5O8mi5Y657UyuUozX34ErfVdZ81g6oVcKFQZ60LhCzk7jJeykK48gaLhDw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^9.2.1",
-        "@repeaterjs/repeater": "3.0.4",
-        "@types/ws": "^8.0.0",
-        "graphql-ws": "5.12.1",
-        "isomorphic-ws": "5.0.0",
-        "tslib": "^2.4.0",
-        "ws": "8.13.0"
+        "@graphql-tools/executor-common": "^0.0.4",
+        "@graphql-tools/utils": "^10.8.1",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "graphql-ws": "^6.0.3",
+        "isomorphic-ws": "^5.0.0",
+        "tslib": "^2.8.1",
+        "ws": "^8.17.1"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
         },
-        "@repeaterjs/repeater": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
-          "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
           "dev": true
-        },
-        "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-          "dev": true,
-          "requires": {}
         }
       }
     },
     "@graphql-tools/executor-http": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-0.1.10.tgz",
-      "integrity": "sha512-hnAfbKv0/lb9s31LhWzawQ5hghBfHS+gYWtqxME6Rl0Aufq9GltiiLBcl7OVVOnkLF0KhwgbYP1mB5VKmgTGpg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.3.3.tgz",
+      "integrity": "sha512-LIy+l08/Ivl8f8sMiHW2ebyck59JzyzO/yF9SFS4NH6MJZUezA1xThUXCDIKhHiD56h/gPojbkpcFvM2CbNE7A==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-hive/signal": "^1.0.0",
+        "@graphql-tools/executor-common": "^0.0.4",
+        "@graphql-tools/utils": "^10.8.1",
         "@repeaterjs/repeater": "^3.0.4",
-        "@whatwg-node/fetch": "^0.8.1",
-        "dset": "^3.1.2",
-        "extract-files": "^11.0.0",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/fetch": "^0.10.4",
+        "@whatwg-node/promise-helpers": "^1.3.0",
         "meros": "^1.2.1",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "tslib": "^2.8.1"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
         },
-        "@whatwg-node/fetch": {
-          "version": "0.8.8",
-          "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
-          "integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
-          "dev": true,
-          "requires": {
-            "@peculiar/webcrypto": "^1.4.0",
-            "@whatwg-node/node-fetch": "^0.3.6",
-            "busboy": "^1.6.0",
-            "urlpattern-polyfill": "^8.0.0",
-            "web-streams-polyfill": "^3.2.1"
-          }
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+          "dev": true
         }
       }
     },
     "@graphql-tools/executor-legacy-ws": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-0.0.11.tgz",
-      "integrity": "sha512-4ai+NnxlNfvIQ4c70hWFvOZlSUN8lt7yc+ZsrwtNFbFPH/EroIzFMapAxM9zwyv9bH38AdO3TQxZ5zNxgBdvUw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.17.tgz",
+      "integrity": "sha512-TvltY6eL4DY1Vt66Z8kt9jVmNcI+WkvVPQZrPbMCM3rv2Jw/sWvSwzUBezRuWX0sIckMifYVh23VPcGBUKX/wg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/utils": "^10.8.6",
         "@types/ws": "^8.0.0",
-        "isomorphic-ws": "5.0.0",
+        "isomorphic-ws": "^5.0.0",
         "tslib": "^2.4.0",
-        "ws": "8.13.0"
+        "ws": "^8.17.1"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
-        },
-        "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-          "dev": true,
-          "requires": {}
         }
       }
     },
@@ -32060,21 +30830,6 @@
         "unixify": "^1.0.0"
       },
       "dependencies": {
-        "@graphql-tools/graphql-tag-pluck": {
-          "version": "8.3.19",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.19.tgz",
-          "integrity": "sha512-LEw/6IYOUz48HjbWntZXDCzSXsOIM1AyWZrlLoJOrA8QAlhFd8h5Tny7opCypj8FO9VvpPFugWoNDh5InPOEQA==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.26.10",
-            "@babel/parser": "^7.26.10",
-            "@babel/plugin-syntax-import-assertions": "^7.26.0",
-            "@babel/traverse": "^7.26.10",
-            "@babel/types": "^7.26.10",
-            "@graphql-tools/utils": "^10.8.6",
-            "tslib": "^2.4.0"
-          }
-        },
         "@graphql-tools/utils": {
           "version": "10.8.6",
           "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
@@ -32105,38 +30860,6 @@
         "tslib": "^2.4.0"
       },
       "dependencies": {
-        "@graphql-tools/executor-http": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.3.3.tgz",
-          "integrity": "sha512-LIy+l08/Ivl8f8sMiHW2ebyck59JzyzO/yF9SFS4NH6MJZUezA1xThUXCDIKhHiD56h/gPojbkpcFvM2CbNE7A==",
-          "dev": true,
-          "requires": {
-            "@graphql-hive/signal": "^1.0.0",
-            "@graphql-tools/executor-common": "^0.0.4",
-            "@graphql-tools/utils": "^10.8.1",
-            "@repeaterjs/repeater": "^3.0.4",
-            "@whatwg-node/disposablestack": "^0.0.6",
-            "@whatwg-node/fetch": "^0.10.4",
-            "@whatwg-node/promise-helpers": "^1.3.0",
-            "meros": "^1.2.1",
-            "tslib": "^2.8.1"
-          }
-        },
-        "@graphql-tools/graphql-tag-pluck": {
-          "version": "8.3.19",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.19.tgz",
-          "integrity": "sha512-LEw/6IYOUz48HjbWntZXDCzSXsOIM1AyWZrlLoJOrA8QAlhFd8h5Tny7opCypj8FO9VvpPFugWoNDh5InPOEQA==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.26.10",
-            "@babel/parser": "^7.26.10",
-            "@babel/plugin-syntax-import-assertions": "^7.26.0",
-            "@babel/traverse": "^7.26.10",
-            "@babel/types": "^7.26.10",
-            "@graphql-tools/utils": "^10.8.6",
-            "tslib": "^2.4.0"
-          }
-        },
         "@graphql-tools/utils": {
           "version": "10.8.6",
           "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
@@ -32159,108 +30882,163 @@
       }
     },
     "@graphql-tools/graphql-file-loader": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.5.tgz",
-      "integrity": "sha512-OL+7qO1S66TpMK7OGz8Ag2WL08HlxKxrObVSDlxzWbSubWuXM5v959XscYAKRf6daYcVpkfNvO37QjflL9mjhg==",
+      "version": "8.0.19",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.19.tgz",
+      "integrity": "sha512-kyEZL4rRJ5LelfCXL3GLgbMiu5Zd7memZaL8ZxPXGI7DA8On1e5IVBH3zZJwf7LzhjSVnPaHM7O/bRzGvTbXzQ==",
       "dev": true,
       "requires": {
-        "@graphql-tools/import": "6.7.6",
-        "@graphql-tools/utils": "8.12.0",
+        "@graphql-tools/import": "7.0.18",
+        "@graphql-tools/utils": "^10.8.6",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
+          "dev": true,
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@graphql-tools/graphql-tag-pluck": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.5.2.tgz",
-      "integrity": "sha512-RW+H8FqOOLQw0BPXaahYepVSRjuOHw+7IL8Opaa5G5uYGOBxoXR7DceyQ7BcpMgktAOOmpDNQ2WtcboChOJSRA==",
+      "version": "8.3.19",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.19.tgz",
+      "integrity": "sha512-LEw/6IYOUz48HjbWntZXDCzSXsOIM1AyWZrlLoJOrA8QAlhFd8h5Tny7opCypj8FO9VvpPFugWoNDh5InPOEQA==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.16.8",
-        "@babel/plugin-syntax-import-assertions": "^7.20.0",
-        "@babel/traverse": "^7.16.8",
-        "@babel/types": "^7.16.8",
-        "@graphql-tools/utils": "^9.2.1",
+        "@babel/core": "^7.26.10",
+        "@babel/parser": "^7.26.10",
+        "@babel/plugin-syntax-import-assertions": "^7.26.0",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
+        "@graphql-tools/utils": "^10.8.6",
         "tslib": "^2.4.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
         }
       }
     },
     "@graphql-tools/import": {
-      "version": "6.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.6.tgz",
-      "integrity": "sha512-WtUyiO2qCaK/H4u81zAw/NbBvCOzwKl4N+Vl+FqrFCzYobscwL6x6roePyoXM1O3+JJIIn3CETv4kg4kwxaBVw==",
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.18.tgz",
+      "integrity": "sha512-1tw1/1QLB0n5bPWfIrhCRnrHIlbMvbwuifDc98g4FPhJ7OXD+iUQe+IpmD5KHVwYWXWhZOuJuq45DfV/WLNq3A==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.12.0",
+        "@graphql-tools/utils": "^10.8.6",
         "resolve-from": "5.0.0",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
+          "dev": true,
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@graphql-tools/json-file-loader": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.4.6.tgz",
-      "integrity": "sha512-34AfjCitO4NtJ5AcXYLcFF3GDsMVTycrljSaBA2t1d7B4bMPtREDphKXLMc/Uf2zW6IW1i1sZZyrcmArPy1Z8A==",
+      "version": "8.0.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.18.tgz",
+      "integrity": "sha512-JjjIxxewgk8HeMR3npR3YbOkB7fxmdgmqB9kZLWdkRKBxrRXVzhryyq+mhmI0Evzt6pNoHIc3vqwmSctG2sddg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.12.0",
+        "@graphql-tools/utils": "^10.8.6",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
+          "dev": true,
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@graphql-tools/load": {
-      "version": "7.8.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.8.14.tgz",
-      "integrity": "sha512-ASQvP+snHMYm+FhIaLxxFgVdRaM0vrN9wW2BKInQpktwWTXVyk+yP5nQUCEGmn0RTdlPKrffBaigxepkEAJPrg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.1.0.tgz",
+      "integrity": "sha512-OGfOm09VyXdNGJS/rLqZ6ztCiG2g6AMxhwtET8GZXTbnjptFc17GtKwJ3Jv5w7mjJ8dn0BHydvIuEKEUK4ciYw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/schema": "^9.0.18",
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/schema": "^10.0.23",
+        "@graphql-tools/utils": "^10.8.6",
         "p-limit": "3.1.0",
         "tslib": "^2.4.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
         }
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
-      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+      "version": "9.0.24",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.24.tgz",
+      "integrity": "sha512-NzWx/Afl/1qHT3Nm1bghGG2l4jub28AdvtG11PoUlmjcIjnFBJMv4vqL0qnxWe8A82peWo4/TkVdjJRLXwgGEw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/utils": "^10.8.6",
         "tslib": "^2.4.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
         }
@@ -32299,135 +31077,6 @@
         "yaml-ast-parser": "^0.0.43"
       },
       "dependencies": {
-        "@graphql-tools/batch-execute": {
-          "version": "9.0.15",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.15.tgz",
-          "integrity": "sha512-qlWUl6yi87FU5WvyJ0uD81R4Y30oQIuW3mJCjOrEvifyT+f/rEqSZFOhYrofYoZAoTcwqOhy6WgH+b9+AtRYjA==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^10.8.1",
-            "@whatwg-node/promise-helpers": "^1.3.0",
-            "dataloader": "^2.2.3",
-            "tslib": "^2.8.1"
-          }
-        },
-        "@graphql-tools/delegate": {
-          "version": "10.2.17",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.2.17.tgz",
-          "integrity": "sha512-z+LpZrTQCEXA4fbdJcSsvhaMqT4xi/O8B0mP30ENGyTbSfa20QamOQx9jgCiw2ii/ucwxfGMhygwlpZG36EU4w==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/batch-execute": "^9.0.15",
-            "@graphql-tools/executor": "^1.4.7",
-            "@graphql-tools/schema": "^10.0.11",
-            "@graphql-tools/utils": "^10.8.1",
-            "@repeaterjs/repeater": "^3.0.6",
-            "@whatwg-node/promise-helpers": "^1.3.0",
-            "dataloader": "^2.2.3",
-            "dset": "^3.1.2",
-            "tslib": "^2.8.1"
-          }
-        },
-        "@graphql-tools/executor": {
-          "version": "1.4.7",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.4.7.tgz",
-          "integrity": "sha512-U0nK9jzJRP9/9Izf1+0Gggd6K6RNRsheFo1gC/VWzfnsr0qjcOSS9qTjY0OTC5iTPt4tQ+W5Zpw/uc7mebI6aA==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^10.8.6",
-            "@graphql-typed-document-node/core": "^3.2.0",
-            "@repeaterjs/repeater": "^3.0.4",
-            "@whatwg-node/disposablestack": "^0.0.6",
-            "@whatwg-node/promise-helpers": "^1.0.0",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@graphql-tools/executor-graphql-ws": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-2.0.5.tgz",
-          "integrity": "sha512-gI/D9VUzI1Jt1G28GYpvm5ckupgJ5O8mi5Y657UyuUozX34ErfVdZ81g6oVcKFQZ60LhCzk7jJeykK48gaLhDw==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/executor-common": "^0.0.4",
-            "@graphql-tools/utils": "^10.8.1",
-            "@whatwg-node/disposablestack": "^0.0.6",
-            "graphql-ws": "^6.0.3",
-            "isomorphic-ws": "^5.0.0",
-            "tslib": "^2.8.1",
-            "ws": "^8.17.1"
-          }
-        },
-        "@graphql-tools/executor-http": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.3.3.tgz",
-          "integrity": "sha512-LIy+l08/Ivl8f8sMiHW2ebyck59JzyzO/yF9SFS4NH6MJZUezA1xThUXCDIKhHiD56h/gPojbkpcFvM2CbNE7A==",
-          "dev": true,
-          "requires": {
-            "@graphql-hive/signal": "^1.0.0",
-            "@graphql-tools/executor-common": "^0.0.4",
-            "@graphql-tools/utils": "^10.8.1",
-            "@repeaterjs/repeater": "^3.0.4",
-            "@whatwg-node/disposablestack": "^0.0.6",
-            "@whatwg-node/fetch": "^0.10.4",
-            "@whatwg-node/promise-helpers": "^1.3.0",
-            "meros": "^1.2.1",
-            "tslib": "^2.8.1"
-          }
-        },
-        "@graphql-tools/executor-legacy-ws": {
-          "version": "1.1.17",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.17.tgz",
-          "integrity": "sha512-TvltY6eL4DY1Vt66Z8kt9jVmNcI+WkvVPQZrPbMCM3rv2Jw/sWvSwzUBezRuWX0sIckMifYVh23VPcGBUKX/wg==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^10.8.6",
-            "@types/ws": "^8.0.0",
-            "isomorphic-ws": "^5.0.0",
-            "tslib": "^2.4.0",
-            "ws": "^8.17.1"
-          }
-        },
-        "@graphql-tools/merge": {
-          "version": "9.0.24",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.24.tgz",
-          "integrity": "sha512-NzWx/Afl/1qHT3Nm1bghGG2l4jub28AdvtG11PoUlmjcIjnFBJMv4vqL0qnxWe8A82peWo4/TkVdjJRLXwgGEw==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^10.8.6",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@graphql-tools/schema": {
-          "version": "10.0.23",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.23.tgz",
-          "integrity": "sha512-aEGVpd1PCuGEwqTXCStpEkmheTHNdMayiIKH1xDWqYp9i8yKv9FRDgkGrY4RD8TNxnf7iII+6KOBGaJ3ygH95A==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/merge": "^9.0.24",
-            "@graphql-tools/utils": "^10.8.6",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@graphql-tools/url-loader": {
-          "version": "8.0.31",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.31.tgz",
-          "integrity": "sha512-QGP3py6DAdKERHO5D38Oi+6j+v0O3rkBbnLpyOo87rmIRbwE6sOkL5JeHegHs7EEJ279fBX6lMt8ry0wBMGtyA==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/executor-graphql-ws": "^2.0.1",
-            "@graphql-tools/executor-http": "^1.1.9",
-            "@graphql-tools/executor-legacy-ws": "^1.1.17",
-            "@graphql-tools/utils": "^10.8.6",
-            "@graphql-tools/wrap": "^10.0.16",
-            "@types/ws": "^8.0.0",
-            "@whatwg-node/fetch": "^0.10.0",
-            "@whatwg-node/promise-helpers": "^1.0.0",
-            "isomorphic-ws": "^5.0.0",
-            "sync-fetch": "0.6.0-2",
-            "tslib": "^2.4.0",
-            "ws": "^8.17.1"
-          }
-        },
         "@graphql-tools/utils": {
           "version": "10.8.6",
           "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
@@ -32439,19 +31088,6 @@
             "cross-inspect": "1.0.1",
             "dset": "^3.1.4",
             "tslib": "^2.4.0"
-          }
-        },
-        "@graphql-tools/wrap": {
-          "version": "10.0.35",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.35.tgz",
-          "integrity": "sha512-qBga3wo7+GqY+ClGexiyRz9xgy1RWozZryTuGX8usGWPa4wKi/tJS4rKWQQesgB3Fh//SZUCRA5u2nwZaZQw1Q==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/delegate": "^10.2.17",
-            "@graphql-tools/schema": "^10.0.11",
-            "@graphql-tools/utils": "^10.8.1",
-            "@whatwg-node/promise-helpers": "^1.3.0",
-            "tslib": "^2.8.1"
           }
         },
         "agent-base": {
@@ -32493,13 +31129,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        },
-        "graphql-ws": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.5.tgz",
-          "integrity": "sha512-HzYw057ch0hx2gZjkbgk1pur4kAtgljlWRP+Gccudqm3BRrTpExjWCQ9OHdIsq47Y6lHL++1lTvuQHhgRRcevw==",
-          "dev": true,
-          "requires": {}
         },
         "has-flag": {
           "version": "4.0.0",
@@ -32558,71 +31187,62 @@
       }
     },
     "@graphql-tools/schema": {
-      "version": "9.0.19",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
-      "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+      "version": "10.0.23",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.23.tgz",
+      "integrity": "sha512-aEGVpd1PCuGEwqTXCStpEkmheTHNdMayiIKH1xDWqYp9i8yKv9FRDgkGrY4RD8TNxnf7iII+6KOBGaJ3ygH95A==",
       "dev": true,
       "requires": {
-        "@graphql-tools/merge": "^8.4.1",
-        "@graphql-tools/utils": "^9.2.1",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "@graphql-tools/merge": "^9.0.24",
+        "@graphql-tools/utils": "^10.8.6",
+        "tslib": "^2.4.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
         }
       }
     },
     "@graphql-tools/url-loader": {
-      "version": "7.17.18",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.17.18.tgz",
-      "integrity": "sha512-ear0CiyTj04jCVAxi7TvgbnGDIN2HgqzXzwsfcqiVg9cvjT40NcMlZ2P1lZDgqMkZ9oyLTV8Bw6j+SyG6A+xPw==",
+      "version": "8.0.31",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.31.tgz",
+      "integrity": "sha512-QGP3py6DAdKERHO5D38Oi+6j+v0O3rkBbnLpyOo87rmIRbwE6sOkL5JeHegHs7EEJ279fBX6lMt8ry0wBMGtyA==",
       "dev": true,
       "requires": {
-        "@ardatan/sync-fetch": "^0.0.1",
-        "@graphql-tools/delegate": "^9.0.31",
-        "@graphql-tools/executor-graphql-ws": "^0.0.14",
-        "@graphql-tools/executor-http": "^0.1.7",
-        "@graphql-tools/executor-legacy-ws": "^0.0.11",
-        "@graphql-tools/utils": "^9.2.1",
-        "@graphql-tools/wrap": "^9.4.2",
+        "@graphql-tools/executor-graphql-ws": "^2.0.1",
+        "@graphql-tools/executor-http": "^1.1.9",
+        "@graphql-tools/executor-legacy-ws": "^1.1.17",
+        "@graphql-tools/utils": "^10.8.6",
+        "@graphql-tools/wrap": "^10.0.16",
         "@types/ws": "^8.0.0",
-        "@whatwg-node/fetch": "^0.8.0",
+        "@whatwg-node/fetch": "^0.10.0",
+        "@whatwg-node/promise-helpers": "^1.0.0",
         "isomorphic-ws": "^5.0.0",
+        "sync-fetch": "0.6.0-2",
         "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.11",
-        "ws": "^8.12.0"
+        "ws": "^8.17.1"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
-          }
-        },
-        "@whatwg-node/fetch": {
-          "version": "0.8.8",
-          "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
-          "integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
-          "dev": true,
-          "requires": {
-            "@peculiar/webcrypto": "^1.4.0",
-            "@whatwg-node/node-fetch": "^0.3.6",
-            "busboy": "^1.6.0",
-            "urlpattern-polyfill": "^8.0.0",
-            "web-streams-polyfill": "^3.2.1"
           }
         }
       }
@@ -32637,27 +31257,36 @@
       }
     },
     "@graphql-tools/wrap": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.4.2.tgz",
-      "integrity": "sha512-DFcd9r51lmcEKn0JW43CWkkI2D6T9XI1juW/Yo86i04v43O9w2/k4/nx2XTJv4Yv+iXwUw7Ok81PGltwGJSDSA==",
+      "version": "10.0.36",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.36.tgz",
+      "integrity": "sha512-sLm9j/T6mlKklSMOCDjrGMi39MRAUzRXsc8tTugZZl0yJEtfU7tX1UaYJQNVsar7vkjLofaWtS7Jf6vcWgGYgQ==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "^9.0.31",
-        "@graphql-tools/schema": "^9.0.18",
-        "@graphql-tools/utils": "^9.2.1",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "@graphql-tools/delegate": "^10.2.18",
+        "@graphql-tools/schema": "^10.0.11",
+        "@graphql-tools/utils": "^10.8.1",
+        "@whatwg-node/promise-helpers": "^1.3.0",
+        "tslib": "^2.8.1"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+          "dev": true
         }
       }
     },
@@ -33650,39 +32279,6 @@
       "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
       "dev": true,
       "optional": true
-    },
-    "@peculiar/asn1-schema": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.0.tgz",
-      "integrity": "sha512-DtNLAG4vmDrdSJFPe7rypkcj597chNQL7u+2dBtYo5mh7VW2+im6ke+O0NVr8W1f4re4C3F71LhoMb0Yxqa48Q==",
-      "dev": true,
-      "requires": {
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.0"
-      }
-    },
-    "@peculiar/webcrypto": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz",
-      "integrity": "sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==",
-      "dev": true,
-      "requires": {
-        "@peculiar/asn1-schema": "^2.1.6",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0",
-        "webcrypto-core": "^1.7.4"
-      }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.7",
@@ -35082,12 +33678,6 @@
         }
       }
     },
-    "@whatwg-node/events": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
-      "integrity": "sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA==",
-      "dev": true
-    },
     "@whatwg-node/fetch": {
       "version": "0.10.7",
       "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.7.tgz",
@@ -35122,19 +33712,6 @@
           "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
           "dev": true
         }
-      }
-    },
-    "@whatwg-node/node-fetch": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz",
-      "integrity": "sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==",
-      "dev": true,
-      "requires": {
-        "@whatwg-node/events": "^0.0.3",
-        "busboy": "^1.6.0",
-        "fast-querystring": "^1.1.1",
-        "fast-url-parser": "^1.1.3",
-        "tslib": "^2.3.1"
       }
     },
     "@whatwg-node/promise-helpers": {
@@ -35488,17 +34065,6 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
-    },
-    "asn1js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
-      "dev": true,
-      "requires": {
-        "pvtsutils": "^1.3.2",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
-      }
     },
     "ast-types-flow": {
       "version": "0.0.7",
@@ -36028,15 +34594,6 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true
-    },
-    "busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
-      "requires": {
-        "streamsearch": "^1.1.0"
-      }
     },
     "bytes": {
       "version": "3.0.0",
@@ -38228,18 +36785,6 @@
         "tmp": "^0.0.33"
       }
     },
-    "extract-files": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
-      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
-      "dev": true
-    },
-    "fast-decode-uri-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "dev": true
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -38271,37 +36816,11 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "fast-querystring": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
-      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-      "dev": true,
-      "requires": {
-        "fast-decode-uri-component": "^1.0.1"
-      }
-    },
     "fast-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
       "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
       "dev": true
-    },
-    "fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dev": true,
-      "requires": {
-        "punycode": "^1.3.2"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-          "dev": true
-        }
-      }
     },
     "fastq": {
       "version": "1.13.0",
@@ -38911,53 +37430,71 @@
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw=="
     },
     "graphql-config": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.5.0.tgz",
-      "integrity": "sha512-x6D0/cftpLUJ0Ch1e5sj1TZn6Wcxx4oMfmhaG9shM0DKajA9iR+j1z86GSTQ19fShbGvrSSvbIQsHku6aQ6BBw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.1.5.tgz",
+      "integrity": "sha512-mG2LL1HccpU8qg5ajLROgdsBzx/o2M6kgI3uAmoaXiSH9PCUbtIyLomLqUtCFaAeG2YCFsl0M5cfQ9rKmDoMVA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/graphql-file-loader": "^7.3.7",
-        "@graphql-tools/json-file-loader": "^7.3.7",
-        "@graphql-tools/load": "^7.5.5",
-        "@graphql-tools/merge": "^8.2.6",
-        "@graphql-tools/url-loader": "^7.9.7",
-        "@graphql-tools/utils": "^9.0.0",
-        "cosmiconfig": "8.0.0",
-        "jiti": "1.17.1",
-        "minimatch": "4.2.3",
-        "string-env-interpolation": "1.0.1",
+        "@graphql-tools/graphql-file-loader": "^8.0.0",
+        "@graphql-tools/json-file-loader": "^8.0.0",
+        "@graphql-tools/load": "^8.1.0",
+        "@graphql-tools/merge": "^9.0.0",
+        "@graphql-tools/url-loader": "^8.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "cosmiconfig": "^8.1.0",
+        "jiti": "^2.0.0",
+        "minimatch": "^9.0.5",
+        "string-env-interpolation": "^1.0.1",
         "tslib": "^2.4.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "version": "10.8.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+          "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
           "dev": true,
           "requires": {
             "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "dset": "^3.1.4",
             "tslib": "^2.4.0"
           }
         },
-        "cosmiconfig": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
-          "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
-            "import-fresh": "^3.2.1",
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+          "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^3.3.0",
             "js-yaml": "^4.1.0",
-            "parse-json": "^5.0.0",
+            "parse-json": "^5.2.0",
             "path-type": "^4.0.0"
           }
         },
+        "jiti": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+          "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+          "dev": true
+        },
         "minimatch": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.3.tgz",
-          "integrity": "sha512-lIUdtK5hdofgCTu3aT0sOaHsYR37viUuIc0rwnnDXImbwFRcumyLMeZaM0t0I/fgxS6s6JMfu0rLD1Wz9pv1ng==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "^2.0.1"
           }
         }
       }
@@ -38990,9 +37527,9 @@
       }
     },
     "graphql-ws": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.12.1.tgz",
-      "integrity": "sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.5.tgz",
+      "integrity": "sha512-HzYw057ch0hx2gZjkbgk1pur4kAtgljlWRP+Gccudqm3BRrTpExjWCQ9OHdIsq47Y6lHL++1lTvuQHhgRRcevw==",
       "devOptional": true,
       "requires": {}
     },
@@ -44629,21 +43166,6 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
-    "pvtsutils": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
-      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "pvutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
-      "dev": true
-    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -46086,12 +44608,6 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
-    "streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true
-    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -47198,12 +45714,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "urlpattern-polyfill": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
-      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
-      "dev": true
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -47266,12 +45776,6 @@
           "dev": true
         }
       }
-    },
-    "value-or-promise": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
-      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
-      "dev": true
     },
     "vary": {
       "version": "1.1.2",
@@ -47392,19 +45896,6 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
       "dev": true
-    },
-    "webcrypto-core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.5.tgz",
-      "integrity": "sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==",
-      "dev": true,
-      "requires": {
-        "@peculiar/asn1-schema": "^2.1.6",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.1",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
-      }
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -38,7 +38,7 @@
     "@graphql-codegen/typescript": "^4.1.6",
     "@graphql-codegen/typescript-operations": "^4.6.1",
     "@graphql-codegen/typescript-react-apollo": "^4.3.2",
-    "@graphql-eslint/eslint-plugin": "^3.20.1",
+    "@graphql-eslint/eslint-plugin": "^4.4.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.15.18",
     "@types/react": "^19.1.4",


### PR DESCRIPTION
with this upgraded, we no longer depend on an vulnerable version of the `ws` library through an old graphql version