### PR TITLE
fix(cli): ignore missing sections when removing configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ getting started as a contributor to this project.
   - [4.2 | Test the development shell](#42--test-the-development-shell)
 - [Useful development commands](#useful-development-commands)
 - [Submitting changes](#submitting-changes)
+  - [Commit messages are the source of truth](#commit-messages-are-the-source-of-truth)
   - [Push early, push often](#push-early-push-often)
   - [Pull requests are squashed](#pull-requests-are-squashed)
   - [Draft vs Ready](#draft-vs-ready)
@@ -264,6 +265,15 @@ repository, and create a pull request.
 
 If you are in the development shell, you have the `gh` command line tool
 available for use with github.
+
+### Commit messages are the source of truth<a name="commit-messages-are-the-source-of-truth"></a>
+
+Commit subjects and messages are the source of truth for a variety of things,
+including the public-facing changelog (\[`//:CHANGELOG.md`\]\[changelog\]) and
+release descriptions. Writing thorough commit messages is beneficial to anyone
+reviewing a commit, including future you!
+
+Please be sure to read the [commit message guidelines][doc/contrib/commit].
 
 ### Push early, push often<a name="push-early-push-often"></a>
 

--- a/commands/wipe.go
+++ b/commands/wipe.go
@@ -33,6 +33,7 @@ func runWipe(env *execenv.Env) error {
 		_ = env.Backend.Close()
 		return err
 	}
+
 	err = env.Backend.LocalConfig().RemoveAll("git-bug")
 	if err != nil {
 		_ = env.Backend.Close()

--- a/repository/config_mem.go
+++ b/repository/config_mem.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -82,16 +81,10 @@ func (mc *MemConfig) ReadTimestamp(key string) (time.Time, error) {
 // RemoveAll remove all key/value pair matching the key prefix
 func (mc *MemConfig) RemoveAll(keyPrefix string) error {
 	keyPrefix = normalizeKey(keyPrefix)
-	found := false
 	for key := range mc.config {
 		if strings.HasPrefix(key, keyPrefix) {
 			delete(mc.config, key)
-			found = true
 		}
-	}
-
-	if !found {
-		return fmt.Errorf("section not found")
 	}
 
 	return nil

--- a/repository/config_testing.go
+++ b/repository/config_testing.go
@@ -56,7 +56,7 @@ func testConfig(t *testing.T, config Config) {
 	require.ErrorIs(t, err, ErrNoConfigEntry)
 
 	err = config.RemoveAll("section.nonexistingkey")
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	err = config.RemoveAll("section.key")
 	require.NoError(t, err)
@@ -65,18 +65,15 @@ func testConfig(t *testing.T, config Config) {
 	require.ErrorIs(t, err, ErrNoConfigEntry)
 
 	err = config.RemoveAll("nonexistingsection")
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	err = config.RemoveAll("section.time")
 	require.NoError(t, err)
 
 	err = config.RemoveAll("section")
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	_, err = config.ReadString("section.key")
-	require.Error(t, err)
-
-	err = config.RemoveAll("section.key")
 	require.Error(t, err)
 
 	// section + subsections

--- a/repository/gogit_config.go
+++ b/repository/gogit_config.go
@@ -212,27 +212,16 @@ func (cw *goGitConfigWriter) RemoveAll(keyPrefix string) error {
 	case len(split) == 1:
 		if cfg.Raw.HasSection(split[0]) {
 			cfg.Raw.RemoveSection(split[0])
-		} else {
-			return fmt.Errorf("invalid key prefix")
 		}
-	default:
-		if !cfg.Raw.HasSection(split[0]) {
-			return fmt.Errorf("invalid key prefix")
-		}
+	case cfg.Raw.HasSection(split[0]):
 		section := cfg.Raw.Section(split[0])
 		rest := strings.Join(split[1:], ".")
 
-		ok := false
 		if section.HasSubsection(rest) {
 			section.RemoveSubsection(rest)
-			ok = true
 		}
 		if section.HasOption(rest) {
 			section.RemoveOption(rest)
-			ok = true
-		}
-		if !ok {
-			return fmt.Errorf("invalid key prefix")
 		}
 	}
 


### PR DESCRIPTION
This change fixes an error typically encountered in the `git-bug-wipe`
command, caused by overly zealous implementations of
//repository:config.go%ConfigWrite.RemoveAll(). This change refactors
these implementations to only attempt to remove sections that exist,
and ignore non-existent sections.

Closes: #1451
Change-Id: I66e710239915c8601dd70a78ae65eb625e093ef6