### PR TITLE
docs(cli): fix user show command documentation

### DIFF
--- a/commands/user/user_show.go
+++ b/commands/user/user_show.go
@@ -20,7 +20,7 @@ func newUserShowCommand(env *execenv.Env) *cobra.Command {
 	options := userShowOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "user show [USER_ID]",
+		Use:     "show [USER_ID]",
 		Short:   "Display a user identity",
 		PreRunE: execenv.LoadBackendEnsureUser(env),
 		RunE: execenv.CloseBackend(env, func(cmd *cobra.Command, args []string) error {

--- a/doc/man/git-bug-user-show.1
+++ b/doc/man/git-bug-user-show.1
@@ -2,11 +2,11 @@
 .TH "GIT-BUG" "1" "Apr 2019" "Generated from git-bug's source code" ""
 
 .SH NAME
-git-bug-user-user - Display a user identity
+git-bug-user-show - Display a user identity
 
 
 .SH SYNOPSIS
-\fBgit-bug user user show [USER_ID] [flags]\fP
+\fBgit-bug user show [USER_ID] [flags]\fP
 
 
 .SH DESCRIPTION
@@ -19,7 +19,7 @@ Display a user identity
 
 .PP
 \fB-h\fP, \fB--help\fP[=false]
-	help for user
+	help for show
 
 
 .SH SEE ALSO

--- a/doc/man/git-bug-user.1
+++ b/doc/man/git-bug-user.1
@@ -23,4 +23,4 @@ List identities
 
 
 .SH SEE ALSO
-\fBgit-bug(1)\fP, \fBgit-bug-user-adopt(1)\fP, \fBgit-bug-user-new(1)\fP, \fBgit-bug-user-user(1)\fP
+\fBgit-bug(1)\fP, \fBgit-bug-user-adopt(1)\fP, \fBgit-bug-user-new(1)\fP, \fBgit-bug-user-show(1)\fP

--- a/doc/md/git-bug_user.md
+++ b/doc/md/git-bug_user.md
@@ -18,5 +18,5 @@ git-bug user [flags]
 * [git-bug](git-bug.md)	 - A bug tracker embedded in Git
 * [git-bug user adopt](git-bug_user_adopt.md)	 - Adopt an existing identity as your own
 * [git-bug user new](git-bug_user_new.md)	 - Create a new identity
-* [git-bug user user](git-bug_user_user.md)	 - Display a user identity
+* [git-bug user show](git-bug_user_show.md)	 - Display a user identity
 

--- a/doc/md/git-bug_user_show.md
+++ b/doc/md/git-bug_user_show.md
@@ -1,16 +1,16 @@
-## git-bug user user
+## git-bug user show
 
 Display a user identity
 
 ```
-git-bug user user show [USER_ID] [flags]
+git-bug user show [USER_ID] [flags]
 ```
 
 ### Options
 
 ```
   -f, --field string   Select field to display. Valid values are [email,humanId,id,lastModification,lastModificationLamports,login,metadata,name]
-  -h, --help           help for user
+  -h, --help           help for show
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
As pointed out in [this comment](https://github.com/git-bug/git-bug/issues/530#issuecomment-3558997281), the documentation and CLI help incorrectly suggested that the command to display a user identity was `git-bug user user show USER_ID`, but the actual command is `git-bug user show USER_ID`.

This change fixes the `Use` field in `user_show.go` to use correct `show [USER_ID]` form instead of `user show [USER_ID]`, and updates the documentation and manpages accordingly.
