### PR TITLE
fix: mask sensitive authentication tokens in console output

### DIFF
--- a/commands/bridge/bridge_auth_show.go
+++ b/commands/bridge/bridge_auth_show.go
@@ -41,7 +41,13 @@ func runBridgeAuthShow(env *execenv.Env, args []string) error {
 
 	switch cred := cred.(type) {
 	case *auth.Token:
-		env.Out.Printf("Value: %s\n", cred.Value)
+		// Mask the token value to prevent accidental exposure of sensitive
+		// authentication credentials in console output or logs.
+		val := cred.Value
+		if len(val) > 8 {
+			val = val[:4] + strings.Repeat("*", len(val)-8) + val[len(val)-4:]
+		}
+		env.Out.Printf("Value: %s\n", val)
 	}
 
 	env.Out.Println("Metadata:")


### PR DESCRIPTION
Fixes #1545

The runBridgeAuthShow function prints authentication token values in plain text. This exposes sensitive credentials to anyone with access to terminal output or logs.

Fix: mask the token by showing only the first and last 4 characters, replacing the middle with asterisks (e.g., "abcd****wxyz" for a 12-character token). Short tokens are left unmasked to avoid ambiguity.