### PR TITLE
Update README.md

### DIFF
--- a/doc/spec/README.md
+++ b/doc/spec/README.md
@@ -5,7 +5,7 @@ store entities (bugs, pull-requests, …) and identities inside a git repository
 
 For the motivation behind the design — why operations instead of snapshots, why Lamport
 clocks, why git objects — start with
-[Data model - the rational](../data-model-rational.md).
+[Data model - the rational](../design/data-model.md).
 
 
 ## Documents

--- a/doc/spec/dag-entity.md
+++ b/doc/spec/dag-entity.md
@@ -4,7 +4,7 @@ This document is the formal specification for the generic data format used by al
 git-bug (bugs, pull-requests, etc.). It is intended for contributors and for authors of
 third-party clients that read or write git-bug data.
 
-For the motivation behind these design choices, see [Data model - the rational](../data-model-rational.md).
+For the motivation behind these design choices, see [Data model - the rational](../design/data-model.md).
 
 
 ## 1. Overview


### PR DESCRIPTION
fix(doc): Broken link in spec

There are a couple of broken links in the spec that are referencing `[Data model - the rational](../data-model-rational.md)`.  Unfortunately, there doesn't seem to be a document there.  The closest thing I've found is to `../design/data-model.md`, which is where I've pointed the links to.