### PR TITLE
webui: markdown viewer

### DIFF
--- a/webui/src/components/code/__snapshots__/file-content.test.tsx.snap
+++ b/webui/src/components/code/__snapshots__/file-content.test.tsx.snap
@@ -1,0 +1,378 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`FileContent/MarkdownFile matches snapshot 1`] = `
+<div>
+  <div>
+    <div
+      class="mb-3 flex justify-end"
+    >
+      <div
+        class="bg-muted/40 inline-flex items-center gap-0.5 rounded-md border p-0.5"
+      >
+        <button
+          aria-pressed="true"
+          class="flex items-center gap-1.5 rounded-[min(var(--radius-md),8px)] px-2.5 py-1 text-sm font-medium transition-colors bg-background text-foreground shadow-xs"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-eye size-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              r="3"
+            />
+          </svg>
+          Preview
+        </button>
+        <button
+          aria-pressed="false"
+          class="flex items-center gap-1.5 rounded-[min(var(--radius-md),8px)] px-2.5 py-1 text-sm font-medium transition-colors text-muted-foreground hover:text-foreground"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-code-xml size-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m18 16 4-4-4-4"
+            />
+            <path
+              d="m6 8-4 4 4 4"
+            />
+            <path
+              d="m14.5 4-5 16"
+            />
+          </svg>
+          Code
+        </button>
+      </div>
+    </div>
+    <div
+      class="rounded-md border"
+    >
+      <div
+        class="px-6 py-4"
+      >
+        <div
+          class="prose prose-sm dark:prose-invert max-w-none prose-pre:rounded-md prose-pre:border prose-pre:border-border prose-pre:bg-muted prose-pre:text-foreground prose-pre:text-sm prose-pre:overflow-x-auto prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded-sm prose-code:text-sm prose-code:before:content-none prose-code:after:content-none prose-pre:prose-code:bg-transparent prose-pre:prose-code:p-0 prose-img:inline prose-img:my-0"
+        >
+          <h1
+            id="project-title"
+          >
+            Project Title
+            <a
+              aria-hidden="true"
+              href="#project-title"
+              node="[object Object]"
+              tabindex="-1"
+            >
+              <span
+                class="icon icon-link"
+              />
+            </a>
+          </h1>
+          
+
+          <p>
+            A short description with 
+            <strong>
+              bold
+            </strong>
+            , 
+            <em>
+              italic
+            </em>
+            , and a 
+            <a
+              href="https://example.com"
+              node="[object Object]"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              link
+            </a>
+            .
+          </p>
+          
+
+          <h2
+            id="features"
+          >
+            Features
+            <a
+              aria-hidden="true"
+              href="#features"
+              node="[object Object]"
+              tabindex="-1"
+            >
+              <span
+                class="icon icon-link"
+              />
+            </a>
+          </h2>
+          
+
+          <ul>
+            
+
+            <li>
+              Rendered by default
+            </li>
+            
+
+            <li>
+              Toggle to view source
+            </li>
+            
+
+          </ul>
+          
+
+          <pre
+            class="shiki shiki-themes github-light github-dark"
+            style="--shiki-light: #24292e; --shiki-dark: #e1e4e8; --shiki-light-bg: #fff; --shiki-dark-bg: #24292e;"
+            tabindex="0"
+          >
+            <code>
+              <span
+                class="line"
+              >
+                <span
+                  style="--shiki-light: #D73A49; --shiki-dark: #F97583;"
+                >
+                  export
+                </span>
+                <span
+                  style="--shiki-light: #D73A49; --shiki-dark: #F97583;"
+                >
+                   const
+                </span>
+                <span
+                  style="--shiki-light: #005CC5; --shiki-dark: #79B8FF;"
+                >
+                   answer
+                </span>
+                <span
+                  style="--shiki-light: #D73A49; --shiki-dark: #F97583;"
+                >
+                   =
+                </span>
+                <span
+                  style="--shiki-light: #005CC5; --shiki-dark: #79B8FF;"
+                >
+                   42
+                </span>
+                <span
+                  style="--shiki-light: #24292E; --shiki-dark: #E1E4E8;"
+                >
+                  ;
+                </span>
+              </span>
+            </code>
+          </pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FileContent/SourceFile matches snapshot 1`] = `
+<div>
+  <div
+    class="border-border overflow-hidden rounded-md border"
+  >
+    <div
+      class="border-border bg-muted/40 text-muted-foreground flex items-center justify-between border-b px-4 py-2 text-xs"
+    >
+      <span>
+        5
+         lines · 
+        64 B
+      </span>
+      <button
+        class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 size-6 rounded-[min(var(--radius-md),8px)] in-data-[slot=button-group]:rounded-md [&_svg:not([class*='size-'])]:size-3"
+        data-slot="button"
+        tabindex="0"
+        title="Copy"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-copy size-3.5"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            height="14"
+            rx="2"
+            ry="2"
+            width="14"
+            x="8"
+            y="8"
+          />
+          <path
+            d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="_code-block_26d040"
+    >
+      <div
+        class="_code-content_26d040"
+      >
+        <pre
+          class="shiki shiki-themes github-light github-dark"
+          style="--shiki-light: #24292e; --shiki-dark: #e1e4e8; --shiki-light-bg: #fff; --shiki-dark-bg: #24292e;"
+          tabindex="0"
+        >
+          <code>
+            <span
+              class="_line_26d040"
+            >
+              <span
+                class="_line-number_26d040"
+                data-line-number="1"
+              >
+                1
+              </span>
+              <span
+                style="--shiki-light: #D73A49; --shiki-dark: #F97583;"
+              >
+                package
+              </span>
+              <span
+                style="--shiki-light: #6F42C1; --shiki-dark: #B392F0;"
+              >
+                 main
+              </span>
+              
+
+            </span>
+            <span
+              class="_line_26d040"
+            >
+              <span
+                class="_line-number_26d040"
+                data-line-number="2"
+              >
+                2
+              </span>
+              
+
+            </span>
+            <span
+              class="_line_26d040"
+            >
+              <span
+                class="_line-number_26d040"
+                data-line-number="3"
+              >
+                3
+              </span>
+              <span
+                style="--shiki-light: #D73A49; --shiki-dark: #F97583;"
+              >
+                func
+              </span>
+              <span
+                style="--shiki-light: #6F42C1; --shiki-dark: #B392F0;"
+              >
+                 main
+              </span>
+              <span
+                style="--shiki-light: #24292E; --shiki-dark: #E1E4E8;"
+              >
+                () {
+              </span>
+              
+
+            </span>
+            <span
+              class="_line_26d040"
+            >
+              <span
+                class="_line-number_26d040"
+                data-line-number="4"
+              >
+                4
+              </span>
+              <span
+                style="--shiki-light: #6F42C1; --shiki-dark: #B392F0;"
+              >
+                  println
+              </span>
+              <span
+                style="--shiki-light: #24292E; --shiki-dark: #E1E4E8;"
+              >
+                (
+              </span>
+              <span
+                style="--shiki-light: #032F62; --shiki-dark: #9ECBFF;"
+              >
+                "hello"
+              </span>
+              <span
+                style="--shiki-light: #24292E; --shiki-dark: #E1E4E8;"
+              >
+                )
+              </span>
+              
+
+            </span>
+            <span
+              class="_line_26d040"
+            >
+              <span
+                class="_line-number_26d040"
+                data-line-number="5"
+              >
+                5
+              </span>
+              <span
+                style="--shiki-light: #24292E; --shiki-dark: #E1E4E8;"
+              >
+                }
+              </span>
+              
+
+            </span>
+          </code>
+        </pre>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/webui/src/components/code/file-content.stories.tsx
+++ b/webui/src/components/code/file-content.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { withApollo, withCachedFragments, withRepoRouter } from "@/../.storybook/decorators";
+import { makeFragmentData } from "@/__generated__/fragment-masking";
+
+import { FileContent } from "./file-content";
+import { FILE_VIEWER_BLOB_FRAGMENT } from "./file-viewer";
+
+const markdownBlobData = {
+  __typename: "GitBlob" as const,
+  text: `# Project Title
+
+A short description with **bold**, _italic_, and a [link](https://example.com).
+
+## Features
+
+- Rendered by default
+- Toggle to view source
+
+\`\`\`ts
+export const answer = 42;
+\`\`\`
+`,
+  hash: "md123",
+  path: "README.md",
+  size: 200,
+  isBinary: false,
+  isTruncated: false,
+};
+
+const sourceBlobData = {
+  __typename: "GitBlob" as const,
+  text: `package main
+
+func main() {
+  println("hello")
+}`,
+  hash: "go456",
+  path: "main.go",
+  size: 64,
+  isBinary: false,
+  isTruncated: false,
+};
+
+const meta = {
+  component: FileContent,
+  decorators: [
+    withApollo,
+    withCachedFragments(
+      [FILE_VIEWER_BLOB_FRAGMENT, "FileViewerBlob", markdownBlobData],
+      [FILE_VIEWER_BLOB_FRAGMENT, "FileViewerBlob", sourceBlobData],
+    ),
+    withRepoRouter,
+  ],
+  args: { repo: "_", gitRef: "main" },
+  // Skip browser tests — composes FileViewer, whose Shiki WASM engine doesn't
+  // load in Vitest browser mode. Snapshot tests (happy-dom) still cover this.
+  tags: ["!test"],
+} satisfies Meta<typeof FileContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const markdownBlob = makeFragmentData(markdownBlobData, FILE_VIEWER_BLOB_FRAGMENT);
+const sourceBlob = makeFragmentData(sourceBlobData, FILE_VIEWER_BLOB_FRAGMENT);
+
+// Markdown file: rendered by default, with a toggle to view source.
+export const MarkdownFile: Story = {
+  args: { blob: markdownBlob },
+};
+
+// Non-markdown file: falls back to the source viewer (no toggle).
+export const SourceFile: Story = {
+  args: { blob: sourceBlob },
+};

--- a/webui/src/components/code/file-content.test.tsx
+++ b/webui/src/components/code/file-content.test.tsx
@@ -1,0 +1,21 @@
+import { composeStories } from "@storybook/react-vite";
+import { beforeAll, expect, test } from "vitest";
+
+import { getHighlighter } from "@/lib/shiki";
+
+import * as stories from "./file-content.stories";
+
+// Pre-load shiki so the singleton promise is already resolved when
+// the component's useEffect runs.
+beforeAll(async () => {
+  await getHighlighter();
+});
+
+const composed = composeStories(stories);
+
+for (const [name, Story] of Object.entries(composed)) {
+  test(`FileContent/${name} matches snapshot`, async () => {
+    await Story.run();
+    expect(document.body.firstChild).toMatchSnapshot();
+  });
+}

--- a/webui/src/components/code/file-content.tsx
+++ b/webui/src/components/code/file-content.tsx
@@ -9,16 +9,11 @@ import { useState, type ReactNode } from "react";
 import { useFragment, type FragmentType } from "@/__generated__/fragment-masking";
 import { FileViewer, FILE_VIEWER_BLOB_FRAGMENT } from "@/components/code/file-viewer";
 import { Markdown } from "@/components/content/markdown";
+import { dirname } from "@/lib/path";
 import { cn } from "@/lib/utils";
 
 function isMarkdownPath(path: string): boolean {
   return /\.(?:md|markdown)$/i.test(path);
-}
-
-// Directory containing the file, used to resolve relative links/images.
-function dirname(path: string): string {
-  const slash = path.lastIndexOf("/");
-  return slash === -1 ? "" : path.slice(0, slash);
 }
 
 interface FileContentProps {

--- a/webui/src/components/code/file-content.tsx
+++ b/webui/src/components/code/file-content.tsx
@@ -1,0 +1,95 @@
+// File content view: renders Markdown files with a Preview/Code toggle and
+// falls back to the syntax-highlighted source viewer for everything else.
+// "Code" mode reuses FileViewer so line linking and the raw source stay
+// available.
+
+import { Code2, Eye } from "lucide-react";
+import { useState, type ReactNode } from "react";
+
+import { useFragment, type FragmentType } from "@/__generated__/fragment-masking";
+import { FileViewer, FILE_VIEWER_BLOB_FRAGMENT } from "@/components/code/file-viewer";
+import { Markdown } from "@/components/content/markdown";
+import { cn } from "@/lib/utils";
+
+function isMarkdownPath(path: string): boolean {
+  return /\.(?:md|markdown)$/i.test(path);
+}
+
+// Directory containing the file, used to resolve relative links/images.
+function dirname(path: string): string {
+  const slash = path.lastIndexOf("/");
+  return slash === -1 ? "" : path.slice(0, slash);
+}
+
+interface FileContentProps {
+  blob: FragmentType<typeof FILE_VIEWER_BLOB_FRAGMENT>;
+  /** Repo URL slug ("_" for the default repository). */
+  repo: string;
+  /** Git ref (branch, tag, or hash) the file is viewed at. */
+  gitRef: string;
+}
+
+export function FileContent({ blob: blobProp, repo, gitRef }: FileContentProps) {
+  const blob = useFragment(FILE_VIEWER_BLOB_FRAGMENT, blobProp);
+  const [plain, setPlain] = useState(false);
+
+  const text = blob.text;
+  // Non-markdown (or binary) files have no rendered view — show source.
+  if (blob.isBinary || text == null || !isMarkdownPath(blob.path)) {
+    return <FileViewer blob={blobProp} />;
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex justify-end">
+        <div className="bg-muted/40 inline-flex items-center gap-0.5 rounded-md border p-0.5">
+          <ToggleButton active={!plain} onClick={() => setPlain(false)}>
+            <Eye className="size-3.5" />
+            Preview
+          </ToggleButton>
+          <ToggleButton active={plain} onClick={() => setPlain(true)}>
+            <Code2 className="size-3.5" />
+            Code
+          </ToggleButton>
+        </div>
+      </div>
+
+      {plain ? (
+        <FileViewer blob={blobProp} />
+      ) : (
+        <div className="rounded-md border">
+          <div className="px-6 py-4">
+            <Markdown
+              content={text}
+              repoContext={{ repo, ref: gitRef, basePath: dirname(blob.path) }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ToggleButtonProps {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}
+
+function ToggleButton({ active, onClick, children }: ToggleButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "flex items-center gap-1.5 rounded-[min(var(--radius-md),8px)] px-2.5 py-1 text-sm font-medium transition-colors",
+        active
+          ? "bg-background text-foreground shadow-xs"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/webui/src/lib/path.ts
+++ b/webui/src/lib/path.ts
@@ -1,0 +1,9 @@
+// Repository path helpers. Paths are forward-slash separated and relative to
+// the repo root with no leading slash; the root itself is "".
+
+// Directory containing `path`, or "" when `path` is at the repo root.
+// Note: unlike Node's path.dirname, the root is "" rather than ".".
+export function dirname(path: string): string {
+  const slash = path.lastIndexOf("/");
+  return slash === -1 ? "" : path.slice(0, slash);
+}

--- a/webui/src/routes/$repo/_code/blob/$ref/$.tsx
+++ b/webui/src/routes/$repo/_code/blob/$ref/$.tsx
@@ -4,7 +4,7 @@ import { useReadQuery } from "@apollo/client/react";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { graphql } from "@/__generated__/gql";
-import { FileViewer } from "@/components/code/file-viewer";
+import { FileContent } from "@/components/code/file-content";
 import { Skeleton } from "@/components/ui/skeleton";
 
 const BLOB_QUERY = graphql(`
@@ -43,10 +43,11 @@ export const Route = createFileRoute("/$repo/_code/blob/$ref/$")({
 });
 
 function BlobView() {
+  const { repo, ref: gitRef } = Route.useParams();
   const { blobRef } = Route.useLoaderData();
   const { data } = useReadQuery(blobRef);
 
   const blob = data?.repository?.blob;
   if (!blob) return <BlobSkeleton />;
-  return <FileViewer blob={blob} />;
+  return <FileContent blob={blob} repo={repo} gitRef={gitRef} />;
 }


### PR DESCRIPTION
The directory view already renders a folder's README.md as markdown. This adds that same viewer for other markdown files in the repo with a Preview/Code toggle with a FileContent component (with a story and snapshot test). I could see the FileContent component being a switch for other file types as well, like images.