### PR TITLE
feat(bridge): add Azure DevOps (Azure Boards) bridge

### DIFF
--- a/bridge/ado/ado.go
+++ b/bridge/ado/ado.go
@@ -1,0 +1,95 @@
+// Package ado contains the Azure DevOps (Azure Boards) bridge implementation.
+//
+// The bridge synchronises git-bug bugs with Azure DevOps work items in both
+// directions. Authentication is done with a Personal Access Token (PAT), which
+// is sent as HTTP Basic auth (empty username, PAT as password) on every call.
+package ado
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+)
+
+const (
+	target = "azuredevops"
+
+	// defaultBaseURL is the instance root for Azure DevOps Services. On-prem
+	// Azure DevOps Server users override this with --base-url.
+	defaultBaseURL = "https://dev.azure.com"
+
+	// metadata stored on the imported/exported bug and its operations
+	metaKeyAdoID         = "ado-id"           // work item id, e.g. "1234"
+	metaKeyAdoURL        = "ado-url"          // work item REST url
+	metaKeyAdoProject    = "ado-project"      // project name or id
+	metaKeyAdoOrg        = "ado-organization" // organization / collection
+	metaKeyAdoBaseURL    = "ado-base-url"     // instance root url
+	metaKeyAdoDerivedID  = "ado-derived-id"   // derived id for a single field change
+	metaKeyAdoExportTime = "ado-export-time"  // time an operation was exported
+
+	// metadata stored on the user identity
+	metaKeyAdoLogin = "ado-login" // login used to match identities and credentials
+	metaKeyAdoUser  = "ado-user"  // remote user unique key (email/descriptor/id)
+
+	// configuration keys, stored under git-bug.bridge.<name>.*
+	confKeyBaseURL      = "base-url"
+	confKeyOrganization = "organization"
+	confKeyProject      = "project"
+	confKeyDefaultLogin = "default-login"
+	// confKeyCreateType is the work item type used when exporting a new bug.
+	// "Task" exists in every stock process (Basic, Agile, Scrum, CMMI).
+	confKeyCreateType = "create-work-item-type"
+	// confKeyClosedStates is a comma separated list of state names that map to
+	// git-bug's "closed" status. Anything else maps to "open".
+	confKeyClosedStates = "closed-states"
+	// confKeyOpenStateTarget / confKeyClosedStateTarget are the ADO state names
+	// used when exporting a git-bug open/close operation.
+	confKeyOpenStateTarget   = "open-state-target"
+	confKeyClosedStateTarget = "closed-state-target"
+
+	defaultCreateType        = "Task"
+	defaultOpenStateTarget   = "Active"
+	defaultClosedStateTarget = "Closed"
+	defaultTimeout           = 60 * time.Second
+)
+
+// defaultClosedStates lists the stock ADO states that mean "done" across the
+// built-in processes.
+var defaultClosedStates = []string{"Closed", "Done", "Completed", "Removed"}
+
+var _ core.BridgeImpl = &AzureDevOps{}
+
+// AzureDevOps is the main object for the bridge.
+type AzureDevOps struct{}
+
+// Target returns "azuredevops".
+func (*AzureDevOps) Target() string {
+	return target
+}
+
+// LoginMetaKey returns the identity metadata key holding the remote login.
+func (*AzureDevOps) LoginMetaKey() string {
+	return metaKeyAdoLogin
+}
+
+// NewImporter returns the Azure DevOps importer.
+func (*AzureDevOps) NewImporter() core.Importer {
+	return &adoImporter{}
+}
+
+// NewExporter returns the Azure DevOps exporter.
+func (*AzureDevOps) NewExporter() core.Exporter {
+	return &adoExporter{}
+}
+
+// buildClient builds an Azure DevOps REST client from a PAT credential.
+func buildClient(ctx context.Context, baseURL, organization, project string, cred auth.Credential) (*Client, error) {
+	token, ok := cred.(*auth.Token)
+	if !ok {
+		return nil, fmt.Errorf("the azuredevops bridge only supports token (PAT) credentials, got %s", cred.Kind())
+	}
+	return NewClient(ctx, baseURL, organization, project, token.Value), nil
+}

--- a/bridge/ado/client.go
+++ b/bridge/ado/client.go
@@ -1,0 +1,413 @@
+package ado
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// apiVersion is used for the stable work item tracking endpoints.
+	apiVersion = "7.1"
+	// apiVersionComments is required for the work item Comments API, which is
+	// still flagged as preview by Azure DevOps.
+	apiVersionComments = "7.1-preview.4"
+
+	// getWorkItemsBatchSize is the maximum number of ids accepted by the
+	// "get list of work items" endpoint.
+	getWorkItemsBatchSize = 200
+
+	jsonPatchContentType = "application/json-patch+json"
+	jsonContentType      = "application/json"
+)
+
+// Client is a minimal Azure DevOps REST client covering only the work item
+// endpoints the bridge needs. It authenticates with a PAT sent as HTTP Basic
+// auth (empty username, PAT as password).
+type Client struct {
+	baseURL      string // instance root, e.g. https://dev.azure.com
+	organization string
+	project      string
+	token        string
+	http         *http.Client
+	ctx          context.Context
+}
+
+// NewClient builds a new Azure DevOps client.
+func NewClient(ctx context.Context, baseURL, organization, project, token string) *Client {
+	return &Client{
+		baseURL:      strings.TrimRight(baseURL, "/"),
+		organization: organization,
+		project:      project,
+		token:        token,
+		http:         &http.Client{Timeout: defaultTimeout},
+		ctx:          ctx,
+	}
+}
+
+func (c *Client) orgURL() string {
+	return c.baseURL + "/" + url.PathEscape(c.organization)
+}
+
+func (c *Client) projectURL() string {
+	return c.orgURL() + "/" + url.PathEscape(c.project)
+}
+
+// do performs an HTTP request and decodes a JSON response into out (if non-nil).
+func (c *Client) do(method, rawURL, contentType string, body []byte, out interface{}) error {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(c.ctx, method, rawURL, reader)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(":"+c.token)))
+	req.Header.Set("Accept", jsonContentType)
+	if body != nil {
+		req.Header.Set("Content-Type", contentType)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("azure devops API %s %s: %s: %s",
+			method, rawURL, resp.Status, strings.TrimSpace(string(data)))
+	}
+
+	if out != nil && len(data) > 0 {
+		return json.Unmarshal(data, out)
+	}
+	return nil
+}
+
+/*
+ * Data model
+ */
+
+// Identity is an Azure DevOps identity reference. Azure DevOps returns identity
+// fields either as an object or, on older field payloads, as a "Name <email>"
+// string, so UnmarshalJSON accepts both.
+type Identity struct {
+	DisplayName string
+	UniqueName  string
+	ID          string
+	Descriptor  string
+}
+
+func (i *Identity) UnmarshalJSON(data []byte) error {
+	var obj struct {
+		DisplayName string `json:"displayName"`
+		UniqueName  string `json:"uniqueName"`
+		ID          string `json:"id"`
+		Descriptor  string `json:"descriptor"`
+	}
+	if err := json.Unmarshal(data, &obj); err == nil &&
+		(obj.DisplayName != "" || obj.UniqueName != "" || obj.ID != "") {
+		i.DisplayName = obj.DisplayName
+		i.UniqueName = obj.UniqueName
+		i.ID = obj.ID
+		i.Descriptor = obj.Descriptor
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	i.DisplayName, i.UniqueName = parseDisplayString(s)
+	return nil
+}
+
+// Key returns a stable unique key for the identity, preferring the email.
+func (i Identity) Key() string {
+	switch {
+	case i.UniqueName != "":
+		return i.UniqueName
+	case i.Descriptor != "":
+		return i.Descriptor
+	case i.ID != "":
+		return i.ID
+	default:
+		return i.DisplayName
+	}
+}
+
+// Email returns a best-effort email for the identity, or an empty string.
+func (i Identity) Email() string {
+	if strings.Contains(i.UniqueName, "@") {
+		return i.UniqueName
+	}
+	return ""
+}
+
+// Project holds the subset of Azure DevOps project fields the bridge uses.
+type Project struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// WorkItemFields holds the System.* fields the bridge reads.
+type WorkItemFields struct {
+	Title        string    `json:"System.Title"`
+	Description  string    `json:"System.Description"`
+	State        string    `json:"System.State"`
+	WorkItemType string    `json:"System.WorkItemType"`
+	Tags         string    `json:"System.Tags"`
+	CreatedBy    Identity  `json:"System.CreatedBy"`
+	CreatedDate  time.Time `json:"System.CreatedDate"`
+	ChangedDate  time.Time `json:"System.ChangedDate"`
+	AssignedTo   Identity  `json:"System.AssignedTo"`
+}
+
+// WorkItem is a single Azure DevOps work item.
+type WorkItem struct {
+	ID     int            `json:"id"`
+	Rev    int            `json:"rev"`
+	Fields WorkItemFields `json:"fields"`
+	URL    string         `json:"url"`
+}
+
+// FieldUpdate is the old/new value pair for one field in a work item revision.
+type FieldUpdate struct {
+	OldValue interface{} `json:"oldValue"`
+	NewValue interface{} `json:"newValue"`
+}
+
+// WorkItemUpdate is a single revision of a work item, listing the fields that
+// changed in that revision.
+type WorkItemUpdate struct {
+	ID          int                    `json:"id"`
+	Rev         int                    `json:"rev"`
+	RevisedBy   Identity               `json:"revisedBy"`
+	RevisedDate time.Time              `json:"revisedDate"`
+	Fields      map[string]FieldUpdate `json:"fields"`
+}
+
+// Comment is a single work item comment.
+type Comment struct {
+	ID           int       `json:"id"`
+	WorkItemID   int       `json:"workItemId"`
+	Text         string    `json:"text"`
+	CreatedBy    Identity  `json:"createdBy"`
+	CreatedDate  time.Time `json:"createdDate"`
+	ModifiedBy   Identity  `json:"modifiedBy"`
+	ModifiedDate time.Time `json:"modifiedDate"`
+	URL          string    `json:"url"`
+}
+
+// patchOp is a single JSON Patch operation used to create or update work items.
+type patchOp struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+/*
+ * Endpoints
+ */
+
+// GetProject fetches project metadata, used to verify access during Configure.
+func (c *Client) GetProject() (*Project, error) {
+	u := fmt.Sprintf("%s/_apis/projects/%s?api-version=%s",
+		c.orgURL(), url.PathEscape(c.project), apiVersion)
+	var p Project
+	if err := c.do(http.MethodGet, u, "", nil, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// SearchWorkItemIDs runs a WIQL query and returns the matching work item ids.
+func (c *Client) SearchWorkItemIDs(wiql string) ([]int, error) {
+	u := fmt.Sprintf("%s/_apis/wit/wiql?api-version=%s", c.projectURL(), apiVersion)
+	body, err := json.Marshal(struct {
+		Query string `json:"query"`
+	}{Query: wiql})
+	if err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		WorkItems []struct {
+			ID int `json:"id"`
+		} `json:"workItems"`
+	}
+	if err := c.do(http.MethodPost, u, jsonContentType, body, &resp); err != nil {
+		return nil, err
+	}
+
+	ids := make([]int, len(resp.WorkItems))
+	for i, wi := range resp.WorkItems {
+		ids[i] = wi.ID
+	}
+	return ids, nil
+}
+
+// GetWorkItems fetches work items by id, transparently batching to respect the
+// Azure DevOps per-call limit.
+func (c *Client) GetWorkItems(ids []int) ([]WorkItem, error) {
+	var out []WorkItem
+	for start := 0; start < len(ids); start += getWorkItemsBatchSize {
+		end := start + getWorkItemsBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+
+		strIDs := make([]string, 0, end-start)
+		for _, id := range ids[start:end] {
+			strIDs = append(strIDs, strconv.Itoa(id))
+		}
+
+		u := fmt.Sprintf("%s/_apis/wit/workitems?ids=%s&$expand=all&api-version=%s",
+			c.orgURL(), strings.Join(strIDs, ","), apiVersion)
+
+		var resp struct {
+			Count int        `json:"count"`
+			Value []WorkItem `json:"value"`
+		}
+		if err := c.do(http.MethodGet, u, "", nil, &resp); err != nil {
+			return nil, err
+		}
+		out = append(out, resp.Value...)
+	}
+	return out, nil
+}
+
+// GetWorkItem fetches a single work item by id.
+func (c *Client) GetWorkItem(id int) (*WorkItem, error) {
+	u := fmt.Sprintf("%s/_apis/wit/workitems/%d?$expand=all&api-version=%s",
+		c.orgURL(), id, apiVersion)
+	var wi WorkItem
+	if err := c.do(http.MethodGet, u, "", nil, &wi); err != nil {
+		return nil, err
+	}
+	return &wi, nil
+}
+
+// GetUpdates returns the revision history of a work item.
+func (c *Client) GetUpdates(workItemID int) ([]WorkItemUpdate, error) {
+	u := fmt.Sprintf("%s/_apis/wit/workItems/%d/updates?api-version=%s",
+		c.projectURL(), workItemID, apiVersion)
+	var resp struct {
+		Count int              `json:"count"`
+		Value []WorkItemUpdate `json:"value"`
+	}
+	if err := c.do(http.MethodGet, u, "", nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Value, nil
+}
+
+// GetComments returns all comments of a work item.
+func (c *Client) GetComments(workItemID int) ([]Comment, error) {
+	u := fmt.Sprintf("%s/_apis/wit/workItems/%d/comments?api-version=%s",
+		c.projectURL(), workItemID, apiVersionComments)
+	var resp struct {
+		TotalCount int       `json:"totalCount"`
+		Count      int       `json:"count"`
+		Comments   []Comment `json:"comments"`
+	}
+	if err := c.do(http.MethodGet, u, "", nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Comments, nil
+}
+
+// CreateWorkItem creates a new work item of the given type.
+func (c *Client) CreateWorkItem(workItemType string, ops []patchOp) (*WorkItem, error) {
+	u := fmt.Sprintf("%s/_apis/wit/workitems/$%s?api-version=%s",
+		c.projectURL(), url.PathEscape(workItemType), apiVersion)
+	body, err := json.Marshal(ops)
+	if err != nil {
+		return nil, err
+	}
+	var wi WorkItem
+	if err := c.do(http.MethodPost, u, jsonPatchContentType, body, &wi); err != nil {
+		return nil, err
+	}
+	return &wi, nil
+}
+
+// UpdateWorkItem applies a JSON Patch to an existing work item.
+func (c *Client) UpdateWorkItem(id int, ops []patchOp) (*WorkItem, error) {
+	u := fmt.Sprintf("%s/_apis/wit/workitems/%d?api-version=%s",
+		c.orgURL(), id, apiVersion)
+	body, err := json.Marshal(ops)
+	if err != nil {
+		return nil, err
+	}
+	var wi WorkItem
+	if err := c.do(http.MethodPatch, u, jsonPatchContentType, body, &wi); err != nil {
+		return nil, err
+	}
+	return &wi, nil
+}
+
+// AddComment posts a new comment on a work item.
+func (c *Client) AddComment(workItemID int, text string) (*Comment, error) {
+	u := fmt.Sprintf("%s/_apis/wit/workItems/%d/comments?api-version=%s",
+		c.projectURL(), workItemID, apiVersionComments)
+	body, err := json.Marshal(struct {
+		Text string `json:"text"`
+	}{Text: text})
+	if err != nil {
+		return nil, err
+	}
+	var cm Comment
+	if err := c.do(http.MethodPost, u, jsonContentType, body, &cm); err != nil {
+		return nil, err
+	}
+	return &cm, nil
+}
+
+// UpdateComment edits an existing work item comment.
+func (c *Client) UpdateComment(workItemID, commentID int, text string) (*Comment, error) {
+	u := fmt.Sprintf("%s/_apis/wit/workItems/%d/comments/%d?api-version=%s",
+		c.projectURL(), workItemID, commentID, apiVersionComments)
+	body, err := json.Marshal(struct {
+		Text string `json:"text"`
+	}{Text: text})
+	if err != nil {
+		return nil, err
+	}
+	var cm Comment
+	if err := c.do(http.MethodPatch, u, jsonContentType, body, &cm); err != nil {
+		return nil, err
+	}
+	return &cm, nil
+}
+
+// DeleteWorkItem deletes a work item. When destroy is true the item is removed
+// permanently, bypassing the recycle bin (this requires extra permission);
+// otherwise it is moved to the recycle bin. The destroy query parameter is
+// omitted entirely when false, because Azure DevOps treats its mere presence as
+// a permanent-delete request and then denies it without the elevated permission.
+func (c *Client) DeleteWorkItem(id int, destroy bool) error {
+	u := fmt.Sprintf("%s/_apis/wit/workitems/%d?api-version=%s", c.orgURL(), id, apiVersion)
+	if destroy {
+		u += "&destroy=true"
+	}
+	return c.do(http.MethodDelete, u, "", nil, nil)
+}

--- a/bridge/ado/client_test.go
+++ b/bridge/ado/client_test.go
@@ -1,0 +1,210 @@
+package ado
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestClient spins up an httptest server with the given handler and returns
+// a Client pointed at it.
+func newTestClient(t *testing.T, handler http.HandlerFunc) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	c := NewClient(context.Background(), srv.URL, "myorg", "myproj", "SECRET")
+	return c, srv
+}
+
+func TestClientAuthHeader(t *testing.T) {
+	var gotAuth string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"id":"p","name":"myproj"}`))
+	})
+	defer srv.Close()
+
+	if _, err := c.GetProject(); err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(":SECRET"))
+	if gotAuth != wantAuth {
+		t.Errorf("auth header = %q, want %q", gotAuth, wantAuth)
+	}
+}
+
+func TestClientGetProjectPath(t *testing.T) {
+	var gotPath string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"id":"guid","name":"myproj"}`))
+	})
+	defer srv.Close()
+
+	p, err := c.GetProject()
+	if err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+	if gotPath != "/myorg/_apis/projects/myproj" {
+		t.Errorf("path = %q, want /myorg/_apis/projects/myproj", gotPath)
+	}
+	if p.Name != "myproj" || p.ID != "guid" {
+		t.Errorf("project = %+v", p)
+	}
+}
+
+func TestClientSearchWorkItemIDs(t *testing.T) {
+	var gotQuery string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &req)
+		gotQuery = req.Query
+		_, _ = w.Write([]byte(`{"workItems":[{"id":1},{"id":2},{"id":3}]}`))
+	})
+	defer srv.Close()
+
+	ids, err := c.SearchWorkItemIDs("SELECT [System.Id] FROM WorkItems")
+	if err != nil {
+		t.Fatalf("SearchWorkItemIDs: %v", err)
+	}
+	if len(ids) != 3 || ids[0] != 1 || ids[2] != 3 {
+		t.Errorf("ids = %v, want [1 2 3]", ids)
+	}
+	if !strings.Contains(gotQuery, "System.Id") {
+		t.Errorf("query not forwarded: %q", gotQuery)
+	}
+}
+
+func TestClientGetWorkItems(t *testing.T) {
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.RawQuery, "ids=10,11") {
+			t.Errorf("missing ids in query: %q", r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`{"count":2,"value":[
+			{"id":10,"rev":1,"fields":{"System.Title":"First","System.State":"New","System.CreatedBy":{"displayName":"A","uniqueName":"a@x.com"}}},
+			{"id":11,"rev":3,"fields":{"System.Title":"Second","System.State":"Closed","System.Tags":"bug; ui"}}
+		]}`))
+	})
+	defer srv.Close()
+
+	items, err := c.GetWorkItems([]int{10, 11})
+	if err != nil {
+		t.Fatalf("GetWorkItems: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	if items[0].Fields.Title != "First" || items[0].Fields.CreatedBy.Key() != "a@x.com" {
+		t.Errorf("item0 = %+v", items[0])
+	}
+	if items[1].Fields.State != "Closed" || joinTags(parseTags(items[1].Fields.Tags)) != "bug; ui" {
+		t.Errorf("item1 = %+v", items[1])
+	}
+}
+
+func TestClientCreateWorkItem(t *testing.T) {
+	var gotPath, gotContentType string
+	var gotOps []patchOp
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotOps)
+		_, _ = w.Write([]byte(`{"id":42,"rev":1,"url":"http://x/42","fields":{"System.Title":"T"}}`))
+	})
+	defer srv.Close()
+
+	wi, err := c.CreateWorkItem("Task", []patchOp{
+		{Op: "add", Path: "/fields/System.Title", Value: "T"},
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if wi.ID != 42 {
+		t.Errorf("created id = %d, want 42", wi.ID)
+	}
+	if gotPath != "/myorg/myproj/_apis/wit/workitems/$Task" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotContentType != jsonPatchContentType {
+		t.Errorf("content-type = %q, want %q", gotContentType, jsonPatchContentType)
+	}
+	if len(gotOps) != 1 || gotOps[0].Path != "/fields/System.Title" {
+		t.Errorf("ops = %+v", gotOps)
+	}
+}
+
+func TestClientAddComment(t *testing.T) {
+	var gotPath string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Text string `json:"text"`
+		}
+		_ = json.Unmarshal(body, &req)
+		_, _ = w.Write([]byte(`{"id":7,"text":"` + req.Text + `"}`))
+	})
+	defer srv.Close()
+
+	cm, err := c.AddComment(42, "hello world")
+	if err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	if cm.ID != 7 || cm.Text != "hello world" {
+		t.Errorf("comment = %+v", cm)
+	}
+	if gotPath != "/myorg/myproj/_apis/wit/workItems/42/comments" {
+		t.Errorf("path = %q", gotPath)
+	}
+}
+
+func TestClientErrorStatus(t *testing.T) {
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"TF400813: unauthorized"}`))
+	})
+	defer srv.Close()
+
+	_, err := c.GetProject()
+	if err == nil {
+		t.Fatal("expected error on 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error = %v, want it to mention 401", err)
+	}
+}
+
+func TestClientDeleteWorkItem(t *testing.T) {
+	var gotMethod, gotQuery string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotQuery = r.URL.RawQuery
+	})
+	defer srv.Close()
+
+	if err := c.DeleteWorkItem(42, false); err != nil {
+		t.Fatalf("DeleteWorkItem(recycle): %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	if strings.Contains(gotQuery, "destroy") {
+		t.Errorf("recycle-bin delete must omit the destroy param, got query %q", gotQuery)
+	}
+
+	if err := c.DeleteWorkItem(42, true); err != nil {
+		t.Fatalf("DeleteWorkItem(destroy): %v", err)
+	}
+	if !strings.Contains(gotQuery, "destroy=true") {
+		t.Errorf("permanent delete must include destroy=true, got query %q", gotQuery)
+	}
+}

--- a/bridge/ado/config.go
+++ b/bridge/ado/config.go
@@ -1,0 +1,166 @@
+package ado
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/commands/input"
+)
+
+const moreConfigText = `
+NOTE: There are a few optional configuration values that you can set in your git
+configuration to influence the behavior of the bridge:
+  - git-bug.bridge.<name>.create-work-item-type (default "Task")
+  - git-bug.bridge.<name>.closed-states (default "Closed, Done, Completed, Removed")
+  - git-bug.bridge.<name>.open-state-target (default "Active")
+  - git-bug.bridge.<name>.closed-state-target (default "Closed")
+`
+
+const patHelpText = `
+The Azure DevOps bridge authenticates with a Personal Access Token (PAT). Create
+one at https://dev.azure.com/<organization>/_usersSettings/tokens with at least
+the "Work Items (Read & Write)" scope.`
+
+func (*AzureDevOps) ValidParams() map[string]interface{} {
+	return map[string]interface{}{
+		"BaseURL":    nil,
+		"Owner":      nil, // Azure DevOps organization / collection
+		"Project":    nil,
+		"Login":      nil,
+		"CredPrefix": nil,
+		"TokenRaw":   nil,
+	}
+}
+
+// Configure sets up the bridge configuration.
+func (a *AzureDevOps) Configure(repo *cache.RepoCache, params core.BridgeParams, interactive bool) (core.Configuration, error) {
+	var err error
+
+	baseURL := params.BaseURL
+	if baseURL == "" {
+		if interactive {
+			baseURL, err = input.PromptDefault(
+				"Azure DevOps instance URL", "URL", defaultBaseURL, input.Required, input.IsURL)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			baseURL = defaultBaseURL
+		}
+	}
+
+	organization := params.Owner
+	if organization == "" {
+		if !interactive {
+			return nil, fmt.Errorf("non-interactive mode is active; please specify the Azure DevOps organization via the --owner option")
+		}
+		organization, err = input.Prompt("Azure DevOps organization", "organization", input.Required)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	project := params.Project
+	if project == "" {
+		if !interactive {
+			return nil, fmt.Errorf("non-interactive mode is active; please specify the project via the --project option")
+		}
+		project, err = input.Prompt("Azure DevOps project", "project", input.Required)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	login := params.Login
+	if login == "" {
+		if !interactive {
+			return nil, fmt.Errorf("non-interactive mode is active; please specify the login via the --login option")
+		}
+		login, err = input.Prompt("Azure DevOps login (email)", "login", input.Required)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var cred auth.Credential
+	switch {
+	case params.CredPrefix != "":
+		cred, err = auth.LoadWithPrefix(repo, params.CredPrefix)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := cred.(*auth.Token); !ok {
+			return nil, fmt.Errorf("the azuredevops bridge only supports token (PAT) credentials")
+		}
+	default:
+		token := params.TokenRaw
+		if token == "" {
+			if !interactive {
+				return nil, fmt.Errorf("non-interactive mode is active; please specify the PAT via the --token option")
+			}
+			fmt.Println(patHelpText)
+			token, err = input.PromptPassword("Personal Access Token", "token", input.Required)
+			if err != nil {
+				return nil, err
+			}
+		}
+		t := auth.NewToken(target, token)
+		t.SetMetadata(auth.MetaKeyLogin, login)
+		t.SetMetadata(auth.MetaKeyBaseURL, baseURL)
+		cred = t
+	}
+
+	conf := make(core.Configuration)
+	conf[core.ConfigKeyTarget] = target
+	conf[confKeyBaseURL] = baseURL
+	conf[confKeyOrganization] = organization
+	conf[confKeyProject] = project
+	conf[confKeyDefaultLogin] = login
+
+	if err = a.ValidateConfig(conf); err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("Checking project access ...\n")
+	client, err := buildClient(context.TODO(), baseURL, organization, project, cred)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = client.GetProject(); err != nil {
+		return nil, fmt.Errorf(
+			"project %s doesn't exist in organization %s on %s, or the token is invalid: %w",
+			project, organization, baseURL, err)
+	}
+
+	// store the now-validated token
+	if !auth.IdExist(repo, cred.ID()) {
+		if err = auth.Store(repo, cred); err != nil {
+			return nil, err
+		}
+	}
+
+	if err = core.FinishConfig(repo, metaKeyAdoLogin, login); err != nil {
+		return nil, err
+	}
+
+	fmt.Print(moreConfigText)
+	return conf, nil
+}
+
+// ValidateConfig returns an error if a required configuration key is missing.
+func (*AzureDevOps) ValidateConfig(conf core.Configuration) error {
+	if v, ok := conf[core.ConfigKeyTarget]; !ok {
+		return fmt.Errorf("missing %s key", core.ConfigKeyTarget)
+	} else if v != target {
+		return fmt.Errorf("unexpected target name: %v", v)
+	}
+	for _, key := range []string{confKeyBaseURL, confKeyOrganization, confKeyProject, confKeyDefaultLogin} {
+		if _, ok := conf[key]; !ok {
+			return fmt.Errorf("missing %s key", key)
+		}
+	}
+	return nil
+}

--- a/bridge/ado/export.go
+++ b/bridge/ado/export.go
@@ -1,0 +1,364 @@
+package ado
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/entity/dag"
+)
+
+// adoExporter implements the core.Exporter interface.
+type adoExporter struct {
+	conf core.Configuration
+
+	// one client per known identity, plus a default used when a bug's author
+	// has no dedicated credential (the common case for a single service PAT).
+	identityClient map[entity.Id]*Client
+	defaultClient  *Client
+
+	// git-bug operation id -> Azure DevOps id (work item id, or numeric comment
+	// id for AddComment operations). Cleared implicitly per run.
+	cachedOperationIDs map[entity.Id]string
+
+	project *Project
+}
+
+// Init loads every PAT credential of the bridge and prepares one client each.
+func (ae *adoExporter) Init(ctx context.Context, repo *cache.RepoCache, conf core.Configuration) error {
+	ae.conf = conf
+	ae.identityClient = make(map[entity.Id]*Client)
+	ae.cachedOperationIDs = make(map[entity.Id]string)
+
+	creds, err := auth.List(repo,
+		auth.WithTarget(target),
+		auth.WithKind(auth.KindToken),
+		auth.WithMeta(auth.MetaKeyBaseURL, conf[confKeyBaseURL]),
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, cred := range creds {
+		login, ok := cred.GetMetadata(auth.MetaKeyLogin)
+		if !ok {
+			_, _ = fmt.Fprintf(os.Stderr, "credential %s is not tagged with an Azure DevOps login\n", cred.ID().Human())
+			continue
+		}
+
+		client, err := buildClient(ctx, conf[confKeyBaseURL], conf[confKeyOrganization], conf[confKeyProject], cred)
+		if err != nil {
+			return err
+		}
+		if ae.defaultClient == nil {
+			ae.defaultClient = client
+		}
+
+		user, err := repo.Identities().ResolveIdentityImmutableMetadata(metaKeyAdoLogin, login)
+		if entity.IsErrNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if _, ok := ae.identityClient[user.Id()]; !ok {
+			ae.identityClient[user.Id()] = client
+		}
+	}
+
+	if ae.defaultClient == nil {
+		return fmt.Errorf("no credentials for this bridge")
+	}
+
+	ae.project, err = ae.defaultClient.GetProject()
+	return err
+}
+
+// getClientForIdentity returns the client for a given identity, falling back to
+// the default client so a single service PAT can export every bug.
+func (ae *adoExporter) getClientForIdentity(userID entity.Id) *Client {
+	if client, ok := ae.identityClient[userID]; ok {
+		return client
+	}
+	return ae.defaultClient
+}
+
+// ExportAll exports all local bugs and their operations to Azure DevOps.
+func (ae *adoExporter) ExportAll(ctx context.Context, repo *cache.RepoCache, since time.Time) (<-chan core.ExportResult, error) {
+	out := make(chan core.ExportResult)
+
+	go func() {
+		defer close(out)
+
+		for _, id := range repo.Bugs().AllIds() {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			b, err := repo.Bugs().Resolve(id)
+			if err != nil {
+				out <- core.NewExportError(fmt.Errorf("can't load bug: %w", err), id)
+				return
+			}
+
+			snapshot := b.Snapshot()
+			if snapshot.CreateTime.Before(since) {
+				out <- core.NewExportNothing(id, "bug created before the since date")
+				continue
+			}
+
+			if err := ae.exportBug(b, out); err != nil {
+				out <- core.NewExportError(fmt.Errorf("can't export bug: %w", err), id)
+				return
+			}
+		}
+	}()
+
+	return out, nil
+}
+
+// exportBug publishes a bug and its operations to Azure DevOps.
+func (ae *adoExporter) exportBug(b *cache.BugCache, out chan<- core.ExportResult) error {
+	snapshot := b.Snapshot()
+	createOp := snapshot.Operations[0].(*bug.CreateOperation)
+	author := snapshot.Author
+
+	// skip bugs imported from another tracker
+	if origin, ok := snapshot.GetCreateMetadata(core.MetaKeyOrigin); ok && origin != target {
+		out <- core.NewExportNothing(b.Id(), fmt.Sprintf("issue tagged with origin: %s", origin))
+		return nil
+	}
+
+	// skip bugs belonging to another Azure DevOps project (one bridge per project)
+	if project, ok := snapshot.GetCreateMetadata(metaKeyAdoProject); ok &&
+		project != ae.project.ID && project != ae.project.Name {
+		out <- core.NewExportNothing(b.Id(), fmt.Sprintf("issue tagged with project: %s", project))
+		return nil
+	}
+
+	var bugAdoID string
+	if id, ok := snapshot.GetCreateMetadata(metaKeyAdoID); ok {
+		bugAdoID = id
+	} else {
+		client := ae.getClientForIdentity(author.Id())
+
+		ops := []patchOp{
+			{Op: "add", Path: "/fields/System.Title", Value: createOp.Title},
+		}
+		if createOp.Message != "" {
+			ops = append(ops, patchOp{Op: "add", Path: "/fields/System.Description", Value: createOp.Message})
+		}
+
+		workItemType := confOr(ae.conf, confKeyCreateType, defaultCreateType)
+		result, err := client.CreateWorkItem(workItemType, ops)
+		if err != nil {
+			out <- core.NewExportError(fmt.Errorf("creating work item: %w", err), b.Id())
+			return err
+		}
+
+		bugAdoID = strconv.Itoa(result.ID)
+		out <- core.NewExportBug(b.Id())
+
+		if err := ae.markExported(b, createOp.Id(), bugAdoID, result.URL, time.Time{}); err != nil {
+			out <- core.NewExportError(fmt.Errorf("marking operation as exported: %w", err), b.Id())
+			return err
+		}
+		if err := b.CommitAsNeeded(); err != nil {
+			out <- core.NewExportError(fmt.Errorf("bug commit: %w", err), b.Id())
+			return err
+		}
+	}
+
+	ae.cachedOperationIDs[createOp.Id()] = bugAdoID
+
+	adoIDInt, err := strconv.Atoi(bugAdoID)
+	if err != nil {
+		return fmt.Errorf("invalid Azure DevOps id %q: %w", bugAdoID, err)
+	}
+
+	for _, op := range snapshot.Operations[1:] {
+		if _, ok := op.(dag.OperationDoesntChangeSnapshot); ok {
+			continue
+		}
+		// skip operations already present in Azure DevOps (imported or exported)
+		if id, ok := op.GetMetadata(metaKeyAdoID); ok {
+			ae.cachedOperationIDs[op.Id()] = id
+			continue
+		}
+
+		client := ae.getClientForIdentity(op.Author().Id())
+
+		var exportedID string
+		var exportTime time.Time
+
+		switch opr := op.(type) {
+		case *bug.AddCommentOperation:
+			comment, err := client.AddComment(adoIDInt, opr.Message)
+			if err != nil {
+				out <- core.NewExportError(fmt.Errorf("adding comment: %w", err), b.Id())
+				return err
+			}
+			// match the importer's comment id format for idempotency
+			exportedID = fmt.Sprintf("comment-%d", comment.ID)
+			ae.cachedOperationIDs[op.Id()] = strconv.Itoa(comment.ID)
+			out <- core.NewExportComment(b.Id())
+
+		case *bug.EditCommentOperation:
+			if opr.Target == createOp.Id() {
+				wi, err := client.UpdateWorkItem(adoIDInt, []patchOp{
+					{Op: "add", Path: "/fields/System.Description", Value: opr.Message},
+				})
+				if err != nil {
+					out <- core.NewExportError(fmt.Errorf("editing description: %w", err), b.Id())
+					return err
+				}
+				exportedID = bugAdoID
+				exportTime = wi.Fields.ChangedDate
+				out <- core.NewExportCommentEdition(b.Id())
+			} else {
+				commentIDStr, ok := ae.cachedOperationIDs[opr.Target]
+				if !ok {
+					return fmt.Errorf("comment id not found for edit operation")
+				}
+				commentID, err := strconv.Atoi(commentIDStr)
+				if err != nil {
+					return fmt.Errorf("invalid comment id %q: %w", commentIDStr, err)
+				}
+				comment, err := client.UpdateComment(adoIDInt, commentID, opr.Message)
+				if err != nil {
+					out <- core.NewExportError(fmt.Errorf("editing comment: %w", err), b.Id())
+					return err
+				}
+				exportedID = fmt.Sprintf("comment-%d", comment.ID)
+				out <- core.NewExportCommentEdition(b.Id())
+			}
+
+		case *bug.SetStatusOperation:
+			wi, err := client.UpdateWorkItem(adoIDInt, []patchOp{
+				{Op: "add", Path: "/fields/System.State", Value: ae.targetState(opr.Status)},
+			})
+			if err != nil {
+				// a failed transition is not fatal: the target state may not exist
+				// in this project's process.
+				out <- core.NewExportWarning(fmt.Errorf("editing state: %w", err), b.Id())
+				continue
+			}
+			exportedID = bugAdoID
+			exportTime = wi.Fields.ChangedDate
+			out <- core.NewExportStatusChange(b.Id())
+
+		case *bug.SetTitleOperation:
+			wi, err := client.UpdateWorkItem(adoIDInt, []patchOp{
+				{Op: "add", Path: "/fields/System.Title", Value: opr.Title},
+			})
+			if err != nil {
+				out <- core.NewExportError(fmt.Errorf("editing title: %w", err), b.Id())
+				return err
+			}
+			exportedID = bugAdoID
+			exportTime = wi.Fields.ChangedDate
+			out <- core.NewExportTitleEdition(b.Id())
+
+		case *bug.LabelChangeOperation:
+			wi, err := ae.exportLabelChange(client, adoIDInt, opr)
+			if err != nil {
+				out <- core.NewExportError(fmt.Errorf("updating tags: %w", err), b.Id())
+				return err
+			}
+			exportedID = bugAdoID
+			exportTime = wi.Fields.ChangedDate
+			out <- core.NewExportLabelChange(b.Id())
+
+		default:
+			continue
+		}
+
+		if err := ae.markExported(b, op.Id(), exportedID, "", exportTime); err != nil {
+			out <- core.NewExportError(fmt.Errorf("marking operation as exported: %w", err), b.Id())
+			return err
+		}
+		if err := b.CommitAsNeeded(); err != nil {
+			out <- core.NewExportError(fmt.Errorf("bug commit: %w", err), b.Id())
+			return err
+		}
+	}
+
+	return nil
+}
+
+// exportLabelChange applies a git-bug label change to the work item's tags by
+// reading the current tags, applying the delta and writing them back.
+func (ae *adoExporter) exportLabelChange(client *Client, adoID int, opr *bug.LabelChangeOperation) (*WorkItem, error) {
+	wi, err := client.GetWorkItem(adoID)
+	if err != nil {
+		return nil, err
+	}
+
+	tags := parseTags(wi.Fields.Tags)
+	present := make(map[string]bool, len(tags))
+	for _, t := range tags {
+		present[t] = true
+	}
+	for _, l := range opr.Added {
+		if s := l.String(); !present[s] {
+			tags = append(tags, s)
+			present[s] = true
+		}
+	}
+	removed := make(map[string]bool, len(opr.Removed))
+	for _, l := range opr.Removed {
+		removed[l.String()] = true
+	}
+	kept := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if !removed[t] {
+			kept = append(kept, t)
+		}
+	}
+
+	return client.UpdateWorkItem(adoID, []patchOp{
+		{Op: "add", Path: "/fields/System.Tags", Value: joinTags(kept)},
+	})
+}
+
+// targetState maps a git-bug status to the configured Azure DevOps state name.
+func (ae *adoExporter) targetState(status common.Status) string {
+	if status == common.ClosedStatus {
+		return confOr(ae.conf, confKeyClosedStateTarget, defaultClosedStateTarget)
+	}
+	return confOr(ae.conf, confKeyOpenStateTarget, defaultOpenStateTarget)
+}
+
+// markExported tags a git-bug operation with the Azure DevOps id it maps to.
+func (ae *adoExporter) markExported(b *cache.BugCache, opID entity.Id, adoID, url string, exportTime time.Time) error {
+	metadata := map[string]string{
+		metaKeyAdoID:      adoID,
+		metaKeyAdoProject: ae.conf[confKeyProject],
+	}
+	if url != "" {
+		metadata[metaKeyAdoURL] = url
+	}
+	if !exportTime.IsZero() {
+		metadata[metaKeyAdoExportTime] = exportTime.UTC().Format(time.RFC3339)
+	}
+	_, err := b.SetMetadata(opID, metadata)
+	return err
+}
+
+// confOr returns conf[key] if set and non-empty, else the default.
+func confOr(conf core.Configuration, key, def string) string {
+	if v, ok := conf[key]; ok && v != "" {
+		return v
+	}
+	return def
+}

--- a/bridge/ado/export_integration_test.go
+++ b/bridge/ado/export_integration_test.go
@@ -1,0 +1,122 @@
+package ado
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/repository"
+)
+
+// TestADOExporterIntegration drives the real exporter against a live Azure
+// DevOps project. It WRITES one work item and then deletes it, so it is gated
+// behind ADO_TEST_EXPORT in addition to the usual ADO_* variables.
+func TestADOExporterIntegration(t *testing.T) {
+	if os.Getenv("ADO_TEST_EXPORT") == "" {
+		t.Skip("set ADO_TEST_EXPORT=1 (this WRITES a work item to the remote) to run the export test")
+	}
+	org := os.Getenv("ADO_ORG")
+	project := os.Getenv("ADO_PROJECT")
+	pat := os.Getenv("ADO_PAT")
+	baseURL := os.Getenv("ADO_BASE_URL")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	require.NotEmpty(t, org)
+	require.NotEmpty(t, project)
+	require.NotEmpty(t, pat)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	const login = "git-bug-bridge-test@example.com"
+
+	repo := repository.CreateGoGitTestRepo(t, false)
+	backend, err := cache.NewRepoCacheNoEvents(repo)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	author, err := backend.Identities().New("git-bug bridge test", login)
+	require.NoError(t, err)
+	author.SetMetadata(metaKeyAdoLogin, login)
+	require.NoError(t, author.Commit())
+	require.NoError(t, backend.SetUserIdentity(author))
+
+	token := auth.NewToken(target, pat)
+	token.SetMetadata(auth.MetaKeyLogin, login)
+	token.SetMetadata(auth.MetaKeyBaseURL, baseURL)
+	require.NoError(t, auth.Store(repo, token))
+
+	marker := fmt.Sprintf("[git-bug bridge test] safe to delete %d", time.Now().Unix())
+	b, _, err := backend.Bugs().New(marker, "Automated export smoke test. This work item will be deleted.")
+	require.NoError(t, err)
+	_, _, err = b.AddComment("Exported comment from the git-bug Azure DevOps bridge test.")
+	require.NoError(t, err)
+	_, err = b.ForceChangeLabels([]string{"git-bug-bridge-test"}, nil)
+	require.NoError(t, err)
+	_, err = b.Close()
+	require.NoError(t, err)
+	require.NoError(t, b.Commit())
+
+	conf := core.Configuration{
+		core.ConfigKeyTarget:     target,
+		confKeyBaseURL:           baseURL,
+		confKeyOrganization:      org,
+		confKeyProject:           project,
+		confKeyDefaultLogin:      login,
+		confKeyCreateType:        "Task",
+		confKeyClosedStateTarget: "Done",
+	}
+	exporter := &adoExporter{}
+	require.NoError(t, exporter.Init(ctx, backend, conf))
+
+	events, err := exporter.ExportAll(ctx, backend, time.Time{})
+	require.NoError(t, err)
+	for ev := range events {
+		require.NoError(t, ev.Err, ev.String())
+	}
+
+	b2, err := backend.Bugs().Resolve(b.Id())
+	require.NoError(t, err)
+	adoIDStr, ok := b2.Snapshot().GetCreateMetadata(metaKeyAdoID)
+	require.True(t, ok, "create operation should be tagged with the Azure DevOps id")
+	adoID, err := strconv.Atoi(adoIDStr)
+	require.NoError(t, err)
+	t.Logf("exported bug %s -> Azure DevOps work item #%d", b.Id().Human(), adoID)
+
+	client := NewClient(ctx, baseURL, org, project, pat)
+
+	t.Cleanup(func() {
+		if err := client.DeleteWorkItem(adoID, true); err == nil {
+			t.Logf("permanently deleted test work item #%d", adoID)
+			return
+		}
+		if err := client.DeleteWorkItem(adoID, false); err == nil {
+			t.Logf("moved test work item #%d to the recycle bin (permanent delete not permitted)", adoID)
+			return
+		}
+		t.Logf("WARNING: could not delete work item #%d, please delete it manually", adoID)
+	})
+
+	wi, err := client.GetWorkItem(adoID)
+	require.NoError(t, err)
+	require.Equal(t, marker, wi.Fields.Title)
+	require.Contains(t, parseTags(wi.Fields.Tags), "git-bug-bridge-test")
+	require.True(t, isClosedState(wi.Fields.State, defaultClosedStates),
+		"remote state %q should map to closed", wi.Fields.State)
+	t.Logf("verified remote work item: title=%q type=%q state=%q tags=%v",
+		wi.Fields.Title, wi.Fields.WorkItemType, wi.Fields.State, parseTags(wi.Fields.Tags))
+
+	comments, err := client.GetComments(adoID)
+	require.NoError(t, err)
+	require.NotEmpty(t, comments)
+	t.Logf("verified %d remote comment(s)", len(comments))
+}

--- a/bridge/ado/import.go
+++ b/bridge/ado/import.go
@@ -1,0 +1,468 @@
+package ado
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/bridge/core/auth"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/entity"
+	"github.com/git-bug/git-bug/util/text"
+)
+
+// adoImporter implements the core.Importer interface.
+type adoImporter struct {
+	conf   core.Configuration
+	client *Client
+
+	// send-only channel
+	out chan<- core.ImportResult
+}
+
+// Init loads the PAT credential and builds the REST client.
+func (ai *adoImporter) Init(ctx context.Context, repo *cache.RepoCache, conf core.Configuration) error {
+	ai.conf = conf
+
+	creds, err := auth.List(repo,
+		auth.WithTarget(target),
+		auth.WithKind(auth.KindToken),
+		auth.WithMeta(auth.MetaKeyBaseURL, conf[confKeyBaseURL]),
+		auth.WithMeta(auth.MetaKeyLogin, conf[confKeyDefaultLogin]),
+	)
+	if err != nil {
+		return err
+	}
+	if len(creds) == 0 {
+		return fmt.Errorf("no credential for this bridge, run \"git bug bridge auth\" or reconfigure")
+	}
+
+	ai.client, err = buildClient(ctx, conf[confKeyBaseURL], conf[confKeyOrganization], conf[confKeyProject], creds[0])
+	return err
+}
+
+// ImportAll imports all work items changed since the given time.
+func (ai *adoImporter) ImportAll(ctx context.Context, repo *cache.RepoCache, since time.Time) (<-chan core.ImportResult, error) {
+	out := make(chan core.ImportResult)
+	ai.out = out
+
+	go func() {
+		defer close(out)
+
+		ids, err := ai.client.SearchWorkItemIDs(buildWiql(ai.conf[confKeyProject], since))
+		if err != nil {
+			out <- core.NewImportError(fmt.Errorf("wiql query: %w", err), "")
+			return
+		}
+
+		items, err := ai.client.GetWorkItems(ids)
+		if err != nil {
+			out <- core.NewImportError(fmt.Errorf("fetching work items: %w", err), "")
+			return
+		}
+
+		for _, wi := range items {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			if !since.IsZero() && !wi.Fields.ChangedDate.IsZero() && wi.Fields.ChangedDate.Before(since) {
+				continue
+			}
+
+			b, err := ai.ensureWorkItem(repo, wi)
+			if err != nil {
+				out <- core.NewImportError(fmt.Errorf("work item %d: %w", wi.ID, err), "")
+				return
+			}
+
+			comments, err := ai.client.GetComments(wi.ID)
+			if err != nil {
+				out <- core.NewImportError(fmt.Errorf("comments for %d: %w", wi.ID, err), b.Id())
+				return
+			}
+			for _, cm := range comments {
+				if err := ai.ensureComment(repo, b, cm); err != nil {
+					out <- core.NewImportError(err, b.Id())
+				}
+			}
+
+			updates, err := ai.client.GetUpdates(wi.ID)
+			if err != nil {
+				out <- core.NewImportError(fmt.Errorf("updates for %d: %w", wi.ID, err), b.Id())
+				return
+			}
+			if err := ai.ensureUpdates(repo, b, wi, updates); err != nil {
+				out <- core.NewImportError(err, b.Id())
+			}
+
+			if !b.NeedCommit() {
+				out <- core.NewImportNothing(b.Id(), "no imported operation")
+			} else if err := b.Commit(); err != nil {
+				out <- core.NewImportError(fmt.Errorf("bug commit: %w", err), b.Id())
+				return
+			}
+		}
+	}()
+
+	return out, nil
+}
+
+// ensurePerson creates or retrieves the identity for an Azure DevOps user.
+func (ai *adoImporter) ensurePerson(repo *cache.RepoCache, user Identity) (*cache.IdentityCache, error) {
+	key := user.Key()
+	if key == "" {
+		key = "unknown"
+	}
+
+	i, err := repo.Identities().ResolveIdentityImmutableMetadata(metaKeyAdoUser, key)
+	if err == nil {
+		return i, nil
+	}
+	if _, ok := err.(entity.ErrMultipleMatch); ok {
+		return nil, err
+	}
+
+	name := user.DisplayName
+	if name == "" {
+		name = key
+	}
+
+	i, err = repo.Identities().NewRaw(
+		name,
+		user.Email(),
+		key,
+		"",
+		nil,
+		map[string]string{
+			metaKeyAdoUser: key,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	ai.out <- core.NewImportIdentity(i.Id())
+	return i, nil
+}
+
+// ensureWorkItem creates a git-bug bug for an Azure DevOps work item.
+func (ai *adoImporter) ensureWorkItem(repo *cache.RepoCache, wi WorkItem) (*cache.BugCache, error) {
+	author, err := ai.ensurePerson(repo, wi.Fields.CreatedBy)
+	if err != nil {
+		return nil, err
+	}
+
+	adoID := fmt.Sprintf("%d", wi.ID)
+
+	b, err := repo.Bugs().ResolveMatcher(func(excerpt *cache.BugExcerpt) bool {
+		if base, ok := excerpt.CreateMetadata[metaKeyAdoBaseURL]; ok && base != ai.conf[confKeyBaseURL] {
+			return false
+		}
+		return excerpt.CreateMetadata[core.MetaKeyOrigin] == target &&
+			excerpt.CreateMetadata[metaKeyAdoID] == adoID &&
+			excerpt.CreateMetadata[metaKeyAdoProject] == ai.conf[confKeyProject]
+	})
+	if err != nil && !entity.IsErrNotFound(err) {
+		return nil, err
+	}
+
+	if entity.IsErrNotFound(err) {
+		createdAt := wi.Fields.CreatedDate
+		if createdAt.IsZero() {
+			createdAt = time.Now()
+		}
+		b, _, err = repo.Bugs().NewRaw(
+			author,
+			createdAt.Unix(),
+			text.CleanupOneLine(wi.Fields.Title),
+			text.Cleanup(wi.Fields.Description),
+			nil,
+			map[string]string{
+				core.MetaKeyOrigin: target,
+				metaKeyAdoID:       adoID,
+				metaKeyAdoURL:      wi.URL,
+				metaKeyAdoProject:  ai.conf[confKeyProject],
+				metaKeyAdoOrg:      ai.conf[confKeyOrganization],
+				metaKeyAdoBaseURL:  ai.conf[confKeyBaseURL],
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		ai.out <- core.NewImportBug(b.Id())
+	}
+
+	return b, nil
+}
+
+// ensureComment imports a single work item comment.
+func (ai *adoImporter) ensureComment(repo *cache.RepoCache, b *cache.BugCache, cm Comment) error {
+	author, err := ai.ensurePerson(repo, cm.CreatedBy)
+	if err != nil {
+		return err
+	}
+
+	commentAdoID := fmt.Sprintf("comment-%d", cm.ID)
+
+	_, err = b.ResolveOperationWithMetadata(metaKeyAdoID, commentAdoID)
+	if err != nil && err != cache.ErrNoMatchingOp {
+		return err
+	}
+	if err == nil {
+		// already imported
+		return nil
+	}
+
+	createdAt := cm.CreatedDate
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+
+	commentID, _, err := b.AddCommentRaw(
+		author,
+		createdAt.Unix(),
+		text.Cleanup(cm.Text),
+		nil,
+		map[string]string{
+			metaKeyAdoID: commentAdoID,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	ai.out <- core.NewImportComment(b.Id(), commentID)
+	return nil
+}
+
+// ensureUpdates replays the revision history of a work item into git-bug
+// operations for status, title, tags and description changes.
+func (ai *adoImporter) ensureUpdates(repo *cache.RepoCache, b *cache.BugCache, wi WorkItem, updates []WorkItemUpdate) error {
+	closedStates := closedStatesFromConf(ai.conf)
+
+	// Map exported operations by their export time so we can recognise the
+	// Azure DevOps revisions that we produced ourselves and avoid re-importing
+	// them.
+	exportedByTime := make(map[int64]entity.Id)
+	for _, op := range b.Snapshot().Operations {
+		if ts, ok := op.GetMetadata(metaKeyAdoExportTime); ok {
+			if t, err := time.Parse(time.RFC3339, ts); err == nil {
+				exportedByTime[t.Unix()] = op.Id()
+			}
+		}
+	}
+
+	for _, up := range updates {
+		// rev 1 is the creation, already handled by ensureWorkItem.
+		if up.Rev <= 1 {
+			continue
+		}
+
+		// Skip revisions we exported ourselves, tagging the causing operation.
+		if opID, ok := exportedByTime[up.RevisedDate.Unix()]; ok {
+			derivedID := fmt.Sprintf("%d-%d", wi.ID, up.Rev)
+			if _, err := b.SetMetadata(opID, map[string]string{metaKeyAdoDerivedID: derivedID}); err != nil {
+				return err
+			}
+			continue
+		}
+
+		author, err := ai.ensurePerson(repo, up.RevisedBy)
+		if err != nil {
+			return err
+		}
+		revisedAt := up.RevisedDate
+		if revisedAt.IsZero() {
+			revisedAt = wi.Fields.ChangedDate
+		}
+
+		if err := ai.importStateChange(b, author, wi, up, revisedAt.Unix(), closedStates); err != nil {
+			return err
+		}
+		if err := ai.importTitleChange(b, author, wi, up, revisedAt.Unix()); err != nil {
+			return err
+		}
+		if err := ai.importTagsChange(b, author, wi, up, revisedAt.Unix()); err != nil {
+			return err
+		}
+		if err := ai.importDescriptionChange(b, author, wi, up, revisedAt.Unix()); err != nil {
+			return err
+		}
+	}
+
+	return ai.reconcileStatus(repo, b, wi, closedStates)
+}
+
+// reconcileStatus corrects the bug's final status to match the work item's
+// current state. It covers work items created directly in a closed state, whose
+// creation revision (skipped above) carries no state transition to replay.
+func (ai *adoImporter) reconcileStatus(repo *cache.RepoCache, b *cache.BugCache, wi WorkItem, closedStates []string) error {
+	desiredClosed := isClosedState(wi.Fields.State, closedStates)
+	if desiredClosed == (b.Snapshot().Status == common.ClosedStatus) {
+		return nil
+	}
+
+	author, err := ai.ensurePerson(repo, wi.Fields.CreatedBy)
+	if err != nil {
+		return err
+	}
+	when := wi.Fields.ChangedDate
+	if when.IsZero() {
+		when = time.Now()
+	}
+
+	metadata := map[string]string{
+		metaKeyAdoID:        fmt.Sprintf("%d", wi.ID),
+		metaKeyAdoDerivedID: fmt.Sprintf("%d-currentstate", wi.ID),
+	}
+
+	var op interface{ Id() entity.Id }
+	if desiredClosed {
+		op, err = b.CloseRaw(author, when.Unix(), metadata)
+	} else {
+		op, err = b.OpenRaw(author, when.Unix(), metadata)
+	}
+	if err != nil {
+		return err
+	}
+	ai.out <- core.NewImportStatusChange(b.Id(), op.Id())
+	return nil
+}
+
+func (ai *adoImporter) alreadyImported(b *cache.BugCache, derivedID string) (bool, error) {
+	_, err := b.ResolveOperationWithMetadata(metaKeyAdoDerivedID, derivedID)
+	if err == nil {
+		return true, nil
+	}
+	if err != cache.ErrNoMatchingOp {
+		return false, err
+	}
+	return false, nil
+}
+
+func (ai *adoImporter) importStateChange(b *cache.BugCache, author *cache.IdentityCache, wi WorkItem, up WorkItemUpdate, unixTime int64, closedStates []string) error {
+	fu, ok := up.Fields["System.State"]
+	if !ok {
+		return nil
+	}
+	oldClosed := isClosedState(fieldString(fu.OldValue), closedStates)
+	newClosed := isClosedState(fieldString(fu.NewValue), closedStates)
+	if oldClosed == newClosed {
+		// open->open or closed->closed: no git-bug status change
+		return nil
+	}
+
+	derivedID := fmt.Sprintf("%d-%d-state", wi.ID, up.Rev)
+	done, err := ai.alreadyImported(b, derivedID)
+	if err != nil || done {
+		return err
+	}
+
+	metadata := map[string]string{
+		metaKeyAdoID:        fmt.Sprintf("%d", wi.ID),
+		metaKeyAdoDerivedID: derivedID,
+	}
+
+	var op interface{ Id() entity.Id }
+	if newClosed {
+		op, err = b.CloseRaw(author, unixTime, metadata)
+	} else {
+		op, err = b.OpenRaw(author, unixTime, metadata)
+	}
+	if err != nil {
+		return err
+	}
+	ai.out <- core.NewImportStatusChange(b.Id(), op.Id())
+	return nil
+}
+
+func (ai *adoImporter) importTitleChange(b *cache.BugCache, author *cache.IdentityCache, wi WorkItem, up WorkItemUpdate, unixTime int64) error {
+	fu, ok := up.Fields["System.Title"]
+	if !ok {
+		return nil
+	}
+	newTitle := fieldString(fu.NewValue)
+
+	derivedID := fmt.Sprintf("%d-%d-title", wi.ID, up.Rev)
+	done, err := ai.alreadyImported(b, derivedID)
+	if err != nil || done {
+		return err
+	}
+
+	op, err := b.SetTitleRaw(author, unixTime, text.CleanupOneLine(newTitle), map[string]string{
+		metaKeyAdoID:        fmt.Sprintf("%d", wi.ID),
+		metaKeyAdoDerivedID: derivedID,
+	})
+	if err != nil {
+		return err
+	}
+	ai.out <- core.NewImportTitleEdition(b.Id(), op.Id())
+	return nil
+}
+
+func (ai *adoImporter) importTagsChange(b *cache.BugCache, author *cache.IdentityCache, wi WorkItem, up WorkItemUpdate, unixTime int64) error {
+	fu, ok := up.Fields["System.Tags"]
+	if !ok {
+		return nil
+	}
+	added, removed := tagSetDifference(parseTags(fieldString(fu.OldValue)), parseTags(fieldString(fu.NewValue)))
+	if len(added) == 0 && len(removed) == 0 {
+		return nil
+	}
+
+	derivedID := fmt.Sprintf("%d-%d-tags", wi.ID, up.Rev)
+	done, err := ai.alreadyImported(b, derivedID)
+	if err != nil || done {
+		return err
+	}
+
+	op, err := b.ForceChangeLabelsRaw(
+		author,
+		unixTime,
+		text.CleanupOneLineArray(added),
+		text.CleanupOneLineArray(removed),
+		map[string]string{
+			metaKeyAdoID:        fmt.Sprintf("%d", wi.ID),
+			metaKeyAdoDerivedID: derivedID,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	ai.out <- core.NewImportLabelChange(b.Id(), op.Id())
+	return nil
+}
+
+func (ai *adoImporter) importDescriptionChange(b *cache.BugCache, author *cache.IdentityCache, wi WorkItem, up WorkItemUpdate, unixTime int64) error {
+	fu, ok := up.Fields["System.Description"]
+	if !ok {
+		return nil
+	}
+	newBody := fieldString(fu.NewValue)
+
+	derivedID := fmt.Sprintf("%d-%d-description", wi.ID, up.Rev)
+	done, err := ai.alreadyImported(b, derivedID)
+	if err != nil || done {
+		return err
+	}
+
+	commentID, _, err := b.EditCreateCommentRaw(
+		author,
+		unixTime,
+		text.Cleanup(newBody),
+		map[string]string{
+			metaKeyAdoID:        fmt.Sprintf("%d", wi.ID),
+			metaKeyAdoDerivedID: derivedID,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	ai.out <- core.NewImportCommentEdition(b.Id(), commentID)
+	return nil
+}

--- a/bridge/ado/integration_test.go
+++ b/bridge/ado/integration_test.go
@@ -1,0 +1,224 @@
+package ado
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/git-bug/git-bug/bridge/core"
+	"github.com/git-bug/git-bug/cache"
+	"github.com/git-bug/git-bug/entities/bug"
+	"github.com/git-bug/git-bug/entities/common"
+	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/text"
+)
+
+// adoTestEnv returns the live test parameters, or skips the test when ADO_TEST
+// is not set. It never writes to the remote.
+func adoTestEnv(t *testing.T) (baseURL, org, project, pat string) {
+	t.Helper()
+	if os.Getenv("ADO_TEST") == "" {
+		t.Skip("set ADO_TEST=1 (plus ADO_ORG, ADO_PROJECT, ADO_PAT) to run the live integration test")
+	}
+	org = os.Getenv("ADO_ORG")
+	project = os.Getenv("ADO_PROJECT")
+	pat = os.Getenv("ADO_PAT")
+	baseURL = os.Getenv("ADO_BASE_URL")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	if org == "" || project == "" || pat == "" {
+		t.Fatal("ADO_ORG, ADO_PROJECT and ADO_PAT must all be set")
+	}
+	return baseURL, org, project, pat
+}
+
+// TestADOIntegration exercises the read-only client path against a real Azure
+// DevOps organization. It never writes to the remote.
+func TestADOIntegration(t *testing.T) {
+	baseURL, org, project, pat := adoTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	c := NewClient(ctx, baseURL, org, project, pat)
+
+	p, err := c.GetProject()
+	require.NoError(t, err)
+	require.NotEmpty(t, p.Name)
+	t.Logf("project: name=%q id=%s", p.Name, p.ID)
+
+	ids, err := c.SearchWorkItemIDs(buildWiql(project, time.Now().AddDate(0, 0, -30)))
+	require.NoError(t, err)
+	if len(ids) == 0 {
+		ids, err = c.SearchWorkItemIDs(buildWiql(project, time.Time{}))
+		require.NoError(t, err)
+	}
+	t.Logf("WIQL matched %d work item id(s)", len(ids))
+	if len(ids) == 0 {
+		t.Skip("no work items in project")
+	}
+
+	sample := ids
+	if len(sample) > 5 {
+		sample = sample[:5]
+	}
+	items, err := c.GetWorkItems(sample)
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+
+	for _, wi := range items {
+		t.Logf("  #%d state=%q closed=%v type=%q author=%q tags=%v title=%q",
+			wi.ID, wi.Fields.State, isClosedState(wi.Fields.State, defaultClosedStates),
+			wi.Fields.WorkItemType, wi.Fields.CreatedBy.Key(),
+			parseTags(wi.Fields.Tags), truncate(wi.Fields.Title, 60))
+		require.False(t, wi.Fields.CreatedDate.IsZero(), "work item #%d has zero CreatedDate", wi.ID)
+	}
+
+	first := items[0].ID
+	comments, err := c.GetComments(first)
+	require.NoError(t, err)
+	t.Logf("work item #%d has %d comment(s)", first, len(comments))
+
+	updates, err := c.GetUpdates(first)
+	require.NoError(t, err)
+	t.Logf("work item #%d has %d revision(s)", first, len(updates))
+}
+
+// TestADOImporterIntegration drives the real importer against a real git-bug
+// backend on a small sample of live work items, then verifies idempotency. It
+// is read-only against Azure DevOps.
+func TestADOImporterIntegration(t *testing.T) {
+	baseURL, org, project, pat := adoTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	c := NewClient(ctx, baseURL, org, project, pat)
+
+	ids, err := c.SearchWorkItemIDs(buildWiql(project, time.Now().AddDate(0, 0, -30)))
+	require.NoError(t, err)
+	if len(ids) == 0 {
+		t.Skip("no recent work items")
+	}
+	// most recently changed items are at the end of the ASC ordering
+	candidates := ids
+	if len(candidates) > 30 {
+		candidates = candidates[len(candidates)-30:]
+	}
+	items, err := c.GetWorkItems(candidates)
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+
+	sample := items
+	if len(sample) > 3 {
+		sample = sample[:3]
+	}
+
+	repo := repository.CreateGoGitTestRepo(t, false)
+	backend, err := cache.NewRepoCacheNoEvents(repo)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	out := make(chan core.ImportResult, 4096)
+	ai := &adoImporter{
+		conf: core.Configuration{
+			confKeyBaseURL:      baseURL,
+			confKeyOrganization: org,
+			confKeyProject:      project,
+		},
+		client: c,
+		out:    out,
+	}
+
+	for _, wi := range sample {
+		b, err := ai.ensureWorkItem(backend, wi)
+		require.NoError(t, err, "ensureWorkItem #%d", wi.ID)
+
+		comments, err := c.GetComments(wi.ID)
+		require.NoError(t, err)
+		for _, cm := range comments {
+			require.NoError(t, ai.ensureComment(backend, b, cm))
+		}
+
+		updates, err := c.GetUpdates(wi.ID)
+		require.NoError(t, err)
+		require.NoError(t, ai.ensureUpdates(backend, b, wi, updates))
+		if b.NeedCommit() {
+			require.NoError(t, b.Commit())
+		}
+
+		snap := b.Snapshot()
+		require.Equal(t, text.CleanupOneLine(wi.Fields.Title), snap.Title, "title mismatch for #%d", wi.ID)
+		opsBefore := len(snap.Operations)
+		t.Logf("bug %s from #%d: %d ops, status=%v (ado state %q) comments=%d revisions=%d title=%q",
+			b.Id().Human(), wi.ID, opsBefore, snap.Status, wi.Fields.State,
+			len(comments), len(updates), truncate(snap.Title, 50))
+
+		b2, err := ai.ensureWorkItem(backend, wi)
+		require.NoError(t, err)
+		for _, cm := range comments {
+			require.NoError(t, ai.ensureComment(backend, b2, cm))
+		}
+		require.NoError(t, ai.ensureUpdates(backend, b2, wi, updates))
+		if b2.NeedCommit() {
+			require.NoError(t, b2.Commit())
+		}
+		require.Equal(t, opsBefore, len(b2.Snapshot().Operations), "second import pass changed op count for #%d", wi.ID)
+	}
+	quoted := make([]string, len(defaultClosedStates))
+	for i, s := range defaultClosedStates {
+		quoted[i] = "'" + escapeWiql(s) + "'"
+	}
+	closedWiql := fmt.Sprintf(
+		"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '%s' AND [System.State] IN (%s) ORDER BY [System.ChangedDate] DESC",
+		escapeWiql(project), strings.Join(quoted, ","))
+	closedIDs, err := c.SearchWorkItemIDs(closedWiql)
+	require.NoError(t, err)
+	if len(closedIDs) > 0 {
+		citems, err := c.GetWorkItems(closedIDs[:1])
+		require.NoError(t, err)
+		require.NotEmpty(t, citems)
+		closed := citems[0]
+
+		b, err := ai.ensureWorkItem(backend, closed)
+		require.NoError(t, err)
+		updates, err := c.GetUpdates(closed.ID)
+		require.NoError(t, err)
+		require.NoError(t, ai.ensureUpdates(backend, b, closed, updates))
+		if b.NeedCommit() {
+			require.NoError(t, b.Commit())
+		}
+		snap := b.Snapshot()
+		require.Equal(t, common.ClosedStatus, snap.Status, "closed work item #%d should import as a closed bug", closed.ID)
+		hasStatusOp := false
+		for _, op := range snap.Operations {
+			if _, ok := op.(*bug.SetStatusOperation); ok {
+				hasStatusOp = true
+				break
+			}
+		}
+		require.True(t, hasStatusOp, "closed work item #%d should have a status-change op", closed.ID)
+		t.Logf("closed item #%d (%q) imported as closed bug %s (%d ops)",
+			closed.ID, closed.Fields.State, b.Id().Human(), len(snap.Operations))
+	} else {
+		t.Log("no closed work items found; skipping close-replay assertion")
+	}
+
+	close(out)
+
+	require.GreaterOrEqual(t, len(backend.Bugs().AllIds()), 1)
+	require.GreaterOrEqual(t, len(backend.Identities().AllIds()), 1)
+	t.Logf("imported %d bug(s), %d identity(ies)",
+		len(backend.Bugs().AllIds()), len(backend.Identities().AllIds()))
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/bridge/ado/mapping.go
+++ b/bridge/ado/mapping.go
@@ -1,0 +1,136 @@
+package ado
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/git-bug/git-bug/bridge/core"
+)
+
+// wiqlDateFormat is the literal format used for WIQL date comparisons. WIQL
+// compares [System.ChangedDate] with date precision and rejects a time
+// component, so the query floors "since" to the day. This over-selects items
+// changed earlier on the same day, which is harmless: the importer is
+// idempotent and ImportAll additionally filters on the precise ChangedDate.
+const wiqlDateFormat = "2006-01-02"
+
+// buildWiql builds the WIQL query used for incremental import. It selects all
+// work item ids in the project changed on or after "since", oldest first so the
+// importer processes history in order.
+func buildWiql(project string, since time.Time) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '%s'",
+		escapeWiql(project))
+	if !since.IsZero() {
+		fmt.Fprintf(&b, " AND [System.ChangedDate] >= '%s'",
+			since.UTC().Format(wiqlDateFormat))
+	}
+	b.WriteString(" ORDER BY [System.ChangedDate] ASC")
+	return b.String()
+}
+
+// escapeWiql escapes a single-quoted WIQL string literal by doubling quotes.
+func escapeWiql(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+// isClosedState reports whether an Azure DevOps state name maps to git-bug's
+// "closed" status. Matching is case-insensitive.
+func isClosedState(state string, closedStates []string) bool {
+	state = strings.TrimSpace(state)
+	for _, cs := range closedStates {
+		if strings.EqualFold(state, strings.TrimSpace(cs)) {
+			return true
+		}
+	}
+	return false
+}
+
+// closedStatesFromConf returns the configured closed-state names, or the
+// built-in default set when unset.
+func closedStatesFromConf(conf core.Configuration) []string {
+	raw, ok := conf[confKeyClosedStates]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return defaultClosedStates
+	}
+	return splitAndTrim(raw, ",")
+}
+
+// parseTags splits an Azure DevOps System.Tags string into individual tags.
+// Azure DevOps stores tags separated by "; ".
+func parseTags(s string) []string {
+	return splitAndTrim(s, ";")
+}
+
+// joinTags renders a tag slice back into the Azure DevOps System.Tags format.
+func joinTags(tags []string) string {
+	return strings.Join(tags, "; ")
+}
+
+// tagSetDifference returns the tags added and removed going from setA to setB.
+func tagSetDifference(setA, setB []string) (added, removed []string) {
+	inA := make(map[string]bool, len(setA))
+	for _, t := range setA {
+		inA[t] = true
+	}
+	inB := make(map[string]bool, len(setB))
+	for _, t := range setB {
+		inB[t] = true
+	}
+	for _, t := range setB {
+		if !inA[t] {
+			added = append(added, t)
+		}
+	}
+	for _, t := range setA {
+		if !inB[t] {
+			removed = append(removed, t)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+	return added, removed
+}
+
+// splitAndTrim splits s on sep, trims whitespace and drops empty entries.
+func splitAndTrim(s, sep string) []string {
+	parts := strings.Split(s, sep)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// parseDisplayString parses an Azure DevOps "Display Name <email>" identity
+// string into its name and email parts.
+func parseDisplayString(s string) (name, email string) {
+	s = strings.TrimSpace(s)
+	open := strings.LastIndex(s, "<")
+	closeIdx := strings.LastIndex(s, ">")
+	if open >= 0 && closeIdx > open {
+		email = strings.TrimSpace(s[open+1 : closeIdx])
+		name = strings.TrimSpace(s[:open])
+		return name, email
+	}
+	return s, ""
+}
+
+// fieldString converts a work item revision field value into a string. Azure
+// DevOps returns the fields the bridge reads (title, state, tags, description)
+// as strings; anything else falls back to fmt formatting, and nil becomes "".
+func fieldString(v interface{}) string {
+	switch val := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return val
+	default:
+		return fmt.Sprint(val)
+	}
+}

--- a/bridge/ado/mapping_test.go
+++ b/bridge/ado/mapping_test.go
@@ -1,0 +1,174 @@
+package ado
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/git-bug/git-bug/bridge/core"
+)
+
+func TestBuildWiql(t *testing.T) {
+	since := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	withSince := buildWiql("My Project", since)
+	want := "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = 'My Project'" +
+		" AND [System.ChangedDate] >= '2026-01-02' ORDER BY [System.ChangedDate] ASC"
+	if withSince != want {
+		t.Errorf("buildWiql with since:\n got: %s\nwant: %s", withSince, want)
+	}
+
+	zero := buildWiql("P", time.Time{})
+	wantZero := "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = 'P' ORDER BY [System.ChangedDate] ASC"
+	if zero != wantZero {
+		t.Errorf("buildWiql zero since:\n got: %s\nwant: %s", zero, wantZero)
+	}
+}
+
+func TestEscapeWiql(t *testing.T) {
+	if got := escapeWiql("O'Brien's Project"); got != "O''Brien''s Project" {
+		t.Errorf("escapeWiql = %q, want %q", got, "O''Brien''s Project")
+	}
+}
+
+func TestIsClosedState(t *testing.T) {
+	cases := []struct {
+		state  string
+		closed bool
+	}{
+		{"New", false},
+		{"Active", false},
+		{"Resolved", false},
+		{"Closed", true},
+		{"closed", true}, // case-insensitive
+		{"Done", true},
+		{"Completed", true},
+		{"Removed", true},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isClosedState(tc.state, defaultClosedStates); got != tc.closed {
+			t.Errorf("isClosedState(%q) = %v, want %v", tc.state, got, tc.closed)
+		}
+	}
+}
+
+func TestClosedStatesFromConf(t *testing.T) {
+	def := closedStatesFromConf(core.Configuration{})
+	if len(def) != len(defaultClosedStates) {
+		t.Errorf("default closed states = %v, want %v", def, defaultClosedStates)
+	}
+
+	custom := closedStatesFromConf(core.Configuration{confKeyClosedStates: "Done, Shipped ,Won't Fix"})
+	want := []string{"Done", "Shipped", "Won't Fix"}
+	if len(custom) != len(want) {
+		t.Fatalf("custom closed states = %v, want %v", custom, want)
+	}
+	for i := range want {
+		if custom[i] != want[i] {
+			t.Errorf("custom[%d] = %q, want %q", i, custom[i], want[i])
+		}
+	}
+}
+
+func TestParseAndJoinTags(t *testing.T) {
+	tags := parseTags("bug; ui ; ; regression")
+	want := []string{"bug", "ui", "regression"}
+	if len(tags) != len(want) {
+		t.Fatalf("parseTags = %v, want %v", tags, want)
+	}
+	for i := range want {
+		if tags[i] != want[i] {
+			t.Errorf("tags[%d] = %q, want %q", i, tags[i], want[i])
+		}
+	}
+
+	if got := joinTags(want); got != "bug; ui; regression" {
+		t.Errorf("joinTags = %q, want %q", got, "bug; ui; regression")
+	}
+	if got := parseTags(""); len(got) != 0 {
+		t.Errorf("parseTags(empty) = %v, want empty", got)
+	}
+}
+
+func TestTagSetDifference(t *testing.T) {
+	added, removed := tagSetDifference(
+		[]string{"a", "b", "c"},
+		[]string{"b", "c", "d", "e"},
+	)
+	if len(added) != 2 || added[0] != "d" || added[1] != "e" {
+		t.Errorf("added = %v, want [d e]", added)
+	}
+	if len(removed) != 1 || removed[0] != "a" {
+		t.Errorf("removed = %v, want [a]", removed)
+	}
+}
+
+func TestParseDisplayString(t *testing.T) {
+	name, email := parseDisplayString("Jane Doe <jane@example.com>")
+	if name != "Jane Doe" || email != "jane@example.com" {
+		t.Errorf("parseDisplayString = (%q, %q), want (Jane Doe, jane@example.com)", name, email)
+	}
+
+	name, email = parseDisplayString("Just A Name")
+	if name != "Just A Name" || email != "" {
+		t.Errorf("parseDisplayString plain = (%q, %q), want (Just A Name, )", name, email)
+	}
+}
+
+func TestFieldString(t *testing.T) {
+	if got := fieldString(nil); got != "" {
+		t.Errorf("fieldString(nil) = %q, want empty", got)
+	}
+	if got := fieldString("hello"); got != "hello" {
+		t.Errorf("fieldString(string) = %q, want hello", got)
+	}
+	if got := fieldString(42); got != "42" {
+		t.Errorf("fieldString(int) = %q, want 42", got)
+	}
+}
+
+func TestConfOr(t *testing.T) {
+	conf := core.Configuration{"a": "x", "b": ""}
+	if got := confOr(conf, "a", "def"); got != "x" {
+		t.Errorf("confOr set = %q, want x", got)
+	}
+	if got := confOr(conf, "b", "def"); got != "def" {
+		t.Errorf("confOr empty = %q, want def", got)
+	}
+	if got := confOr(conf, "missing", "def"); got != "def" {
+		t.Errorf("confOr missing = %q, want def", got)
+	}
+}
+
+func TestIdentityUnmarshalObject(t *testing.T) {
+	var id Identity
+	err := json.Unmarshal([]byte(`{"displayName":"Jane","uniqueName":"jane@x.com","id":"guid-1","descriptor":"desc-1"}`), &id)
+	if err != nil {
+		t.Fatalf("unmarshal object: %v", err)
+	}
+	if id.DisplayName != "Jane" || id.Key() != "jane@x.com" || id.Email() != "jane@x.com" {
+		t.Errorf("identity object = %+v, key=%q email=%q", id, id.Key(), id.Email())
+	}
+}
+
+func TestIdentityUnmarshalString(t *testing.T) {
+	var id Identity
+	err := json.Unmarshal([]byte(`"John Doe <john@x.com>"`), &id)
+	if err != nil {
+		t.Fatalf("unmarshal string: %v", err)
+	}
+	if id.DisplayName != "John Doe" || id.UniqueName != "john@x.com" || id.Key() != "john@x.com" {
+		t.Errorf("identity string = %+v, key=%q", id, id.Key())
+	}
+}
+
+func TestIdentityKeyFallback(t *testing.T) {
+	id := Identity{DisplayName: "No Email"}
+	if id.Key() != "No Email" {
+		t.Errorf("Key fallback = %q, want No Email", id.Key())
+	}
+	if id.Email() != "" {
+		t.Errorf("Email = %q, want empty", id.Email())
+	}
+}

--- a/bridge/bridges.go
+++ b/bridge/bridges.go
@@ -2,6 +2,7 @@
 package bridge
 
 import (
+	"github.com/git-bug/git-bug/bridge/ado"
 	"github.com/git-bug/git-bug/bridge/core"
 	"github.com/git-bug/git-bug/bridge/github"
 	"github.com/git-bug/git-bug/bridge/gitlab"
@@ -12,6 +13,7 @@ import (
 )
 
 func init() {
+	core.Register(&ado.AzureDevOps{})
 	core.Register(&github.Github{})
 	core.Register(&gitlab.Gitlab{})
 	core.Register(&launchpad.Launchpad{})


### PR DESCRIPTION
## Summary

Bidirectional bridge between git-bug and Azure DevOps Boards work items, requested in #1542. Authentication is via Personal Access Token (PAT). The REST client is hand-rolled on `net/http` with **no new dependencies**.

Per @sudoforge's note on #1542: I will maintain this in-tree until the external plugin interface lands, and I take responsibility for issues related to it.

Opening as a **draft** for early feedback on the three scoping questions I raised on #1542 (target name, client approach, single vs. split PR).

## Changes

New `bridge/ado/` package, registered in `bridge/bridges.go`:

- `ado.go`: `BridgeImpl`, metadata/config constants, PAT client builder
- `client.go`: REST client for WIQL, get/create/update/delete work items, updates (revisions), and comments
- `config.go`: `Configure()` PAT flow (interactive and non-interactive)
- `import.go`: incremental WIQL on `System.ChangedDate`, mapping work items, comments, state, tags and description edits to bug operations, with a final-status reconcile for items created directly in a closed state
- `export.go`: create and update work items via JSON Patch, replaying comments, status, title and label changes
- `mapping.go`: pure helpers (WIQL builder, state/tag mapping, identity parsing)

One bridge per Azure DevOps project, matching the Jira bridge model. Config keys beyond base-url/organization/project/login are optional: `create-work-item-type` (default `Task`), `closed-states`, `open-state-target`, `closed-state-target`.

## Test plan

- `go test ./bridge/ado/`: 23 unit tests (mapping logic + `net/http` client via `httptest`)
- `go vet` and `gofmt` clean; `go.mod` / `go.sum` unchanged
- Live-tested end to end against a real Azure DevOps organization:
  - Import: auth, WIQL incremental query, field/identity/tag/comment/revision parsing, importer to git-bug bugs, closed-item replay, and idempotency (a second pass is a no-op)
  - Export: create work item, comment, close and label, then verified on the remote
- Live integration tests are gated behind `ADO_TEST` (read-only) and `ADO_TEST_EXPORT` (writes), matching the github/gitlab bridge convention, so they skip in CI.

## Known follow-ups

- PAT-only auth for now; OAuth can follow.
- Project-scoped; area-path or team scoping could come later.
- A `doc/azuredevops_bridge.md` page once the scoping questions are settled.
